### PR TITLE
Fix for losing all learned skills on edited Pals, Add button to fix broken Pals from saves edited w/previous version

### DIFF
--- a/PalEdit.py
+++ b/PalEdit.py
@@ -305,7 +305,7 @@ def changeattack(num):
     
     if not attacks[num].get() in ["Unknown", "UNKNOWN"]:
         if attacks[num].get() in ["None", "NONE"]:
-            pal.RemoveAttack(num)
+            pal.RemoveAttackSkill(num)
         else:
             pal.SetAttackSkill(num, attacks[num].get())
     

--- a/PalEdit.py
+++ b/PalEdit.py
@@ -307,7 +307,7 @@ def changeattack(num):
         if attacks[num].get() in ["None", "NONE"]:
             pal.RemoveAttack(num)
         else:
-            pal.SetAttack(num, attacks[num].get())
+            pal.SetAttackSkill(num, attacks[num].get())
     
     refresh(i)
 

--- a/PalEdit.py
+++ b/PalEdit.py
@@ -457,6 +457,10 @@ def load(file):
                 palbox[p.owner] = []
             palbox[p.owner].append(p)
 
+            # Update moveset for each Pal in order to fix any save files with Pals that were broken by the bug
+            # Pals will still retain any skills learned from fruits
+            p.SetLevelMoves()
+
             n = p.GetFullName()
 
             for m in p.GetLearntMoves():

--- a/PalEdit.py
+++ b/PalEdit.py
@@ -78,6 +78,19 @@ def toggleDebug():
         frameDebug.pack_forget()
     updateWindowSize()
 
+def fixMoveset():
+    global filename
+    if filename:
+        for player, pals in palbox.items():  # Iterating over each player's pals
+            for pal in pals:  # Iterating over each PalEntity
+                try:
+                    pal.SetLevelMoves()
+                except Exception as e:
+                    unknown.append(pal)
+                    print(f"Error occurred: {str(e)}")
+        messagebox.showinfo("Done", "Pals fixed!")
+    else:
+        messagebox.showinfo("Error", "No file loaded!")
 
 
 def isPalSelected():
@@ -457,10 +470,6 @@ def load(file):
                 palbox[p.owner] = []
             palbox[p.owner].append(p)
 
-            # Update moveset for each Pal in order to fix any save files with Pals that were broken by the bug
-            # Pals will still retain any skills learned from fruits
-            p.SetLevelMoves()
-
             n = p.GetFullName()
 
             for m in p.GetLearntMoves():
@@ -769,6 +778,7 @@ tools.add_cascade(label="File", menu=filemenu, underline=0)
 
 toolmenu = Menu(tools, tearoff=0)
 toolmenu.add_command(label="Debug", command=toggleDebug)
+toolmenu.add_command(label="Fix Pal Movesets", command=fixMoveset)
 # toolmenu.add_command(label="Generate GUID", command=generateguid)
 
 tools.add_cascade(label="Tools", menu=toolmenu, underline=0)

--- a/PalInfo.py
+++ b/PalInfo.py
@@ -357,7 +357,7 @@ class PalEntity:
         if slot < len(self._skills):
             self._skills.pop(slot)
 
-    def RemoveAttack(self, slot):
+    def RemoveAttackSkill(self, slot):
         if slot < len(self._equipMoves):
             self._equipMoves.pop(slot)
         self.SetLevelMoves()

--- a/PalInfo.py
+++ b/PalInfo.py
@@ -299,7 +299,7 @@ class PalEntity:
         else:
             self._skills[slot] = find(skill)
 
-    def SetAttack(self, slot, attack):
+    def SetAttackSkill(self, slot, attack):
         if slot > len(self._equipMoves)-1:
             self._equipMoves.append(find(attack))
         else:

--- a/PalInfo.py
+++ b/PalInfo.py
@@ -3,6 +3,8 @@ import json
 from enum import Enum
 from PIL import ImageTk, Image
 from EmptyObjectHandler import *
+import bs4 as bsoup
+import urllib.request as ureq
 
 
 

--- a/PalInfo.py
+++ b/PalInfo.py
@@ -475,36 +475,39 @@ def find(name):
 if __name__ == "__main__":
     PalObject("Mossanda Noct", "Electric", "Dark")
 
+    with open("resources/data/pals.json", "r+", encoding="utf8") as palfile:
+        p = json.loads(palfile.read())
+        palfile.seek(0)
 
-    if True:
-        import bs4 as bsoup
-        import urllib.request as ureq
-
-        
-        
-        with open("resources/data/pals.json", "r+", encoding="utf8") as palfile:
-            p = json.loads(palfile.read())
-            palfile.seek(0)
-            for pal in p['values']:
-                pal["Moveset"] = {}
+        for pal in p['values']:
+            # Check if the Pal has an existing moveset
+            if "Moveset" in pal and isinstance(pal["Moveset"], dict) and pal["Moveset"]:
+                # If the moveset exists, use it directly
+                continue
+            else:
+                # If the moveset does not exist, fetch it from the website
                 if not "Human" in pal and not "Tower" in pal:
                     n = pal["Name"].lower().replace(" ", "-")
-                    headers = {'User-Agent': 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7'}
+                    headers = {
+                        'User-Agent': 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7'}
                     req = ureq.Request(f"http://palworld.gg/pal/{n}", None, headers)
                     src = ureq.urlopen(req)
                     soup = bsoup.BeautifulSoup(src, "lxml")
 
                     con = soup.find_all("div", {"class": "active skills"})
                     if len(con) > 0:
+                        new_moveset = {}
                         for item in con[0].find_all("div", {"class": "item"}):
-                            
                             name = item.find("div", {"class": "name"}).text
                             level = item.find("div", {"class": "level"})
 
-                            if not level == None:
+                            if level is not None:
                                 level = int(level.text.replace("- Lv ", ""))
-                                pal["Moveset"][name] = level
-            json.dump(p, palfile, indent=4)
+                                new_moveset[name] = level
+                        pal["Moveset"] = new_moveset
+
+        # Dump the updated data back into the JSON file
+        json.dump(p, palfile, indent=4)
             
 
     if True:


### PR DESCRIPTION
- there were two SetAttack defs so I made the second one SetAttackSkill

- Changed a bit more about how movesets are checked

- Added a button that resets all Pal movesets in order to fix any saves that had Pals broken by the bug. They will still remember all fruit skills so this should not have a negative effect on saves w/o bugged Pals. I have tested this out on my own large savefile that had dozens of broken Pals and it fixed them all with no other ill effects.