### PR TITLE
Fix max hp being calculated too early, added boss hp scaling for frostallion, and reflect iv changes on in-game stats immediately

### DIFF
--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -859,32 +859,28 @@ Do you want to use %s's DEFAULT Scaling (%s)?
         if self.phpvar.dirty:
             self.phpvar.dirty = False
             h = self.phpvar.get()
-            self.handleMaxHealthUpdates(pal, changes={
-                'hp_iv': h
-            })
             print(f"{pal.GetFullName()}: TalentHP {pal.GetTalentHP()} -> {h}")
             pal.SetTalentHP(h)
-            # hv = 500 + (((70 * 0.5) * l) * (1 + (h / 100)))
-            # self.hthstatval.config(text=math.floor(hv))
+            self.handleMaxHealthUpdates(pal)
+
         if self.meleevar.dirty:
             self.meleevar.dirty = False
             a = self.meleevar.get()
             print(f"{pal.GetFullName()}: AttackMelee {pal.GetAttackMelee()} -> {a}")
             pal.SetAttackMelee(a)
-            # av = 100 + (((70 * 0.75) * l) * (1 + (a / 100)))
-            # self.atkstatval.config(text=math.floor(av))
+
         if self.shotvar.dirty:
             self.shotvar.dirty = False
             r = self.shotvar.get()
             print(f"{pal.GetFullName()}: AttackRanged {pal.GetAttackRanged()} -> {r}")
             pal.SetAttackRanged(r)
+
         if self.defvar.dirty:
             self.defvar.dirty = False
             d = self.defvar.get()
             print(f"{pal.GetFullName()}: Defence {pal.GetDefence()} -> {d}")
             pal.SetDefence(d)
-            # dv = 50 + (((70 * 0.75) * l) * (1 + (d / 100)))
-            # self.defstatval.config(text=math.floor(dv))
+
         if self.wspvar.dirty:
             self.wspvar.dirty = False
             w = self.wspvar.get()
@@ -931,9 +927,7 @@ Do you want to use %s's DEFAULT Scaling (%s)?
                 break
 
         pal.SetType(self.speciesvar.get())
-        self.handleMaxHealthUpdates(pal, changes={
-            'species': self.speciesvar.get()
-        })
+        self.handleMaxHealthUpdates(pal)
         self.updateDisplay()
         self.refresh(self.palbox[self.players[self.current.get()]].index(pal))
 

--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -506,7 +506,7 @@ class PalEdit():
 
         if not pal.IsTower() and not pal.IsHuman():
             calc = pal.CalculateIngameStats()
-            self.hthstatval.config(text=pal.GetMaxHP())
+            self.hthstatval.config(text=pal.GetMaxHP() / 1000)
             self.atkstatval.config(text=calc["ATK"])
             self.defstatval.config(text=calc["DEF"])
         else:
@@ -862,30 +862,36 @@ Do you want to use %s's DEFAULT Scaling (%s)?
             print(f"{pal.GetFullName()}: TalentHP {pal.GetTalentHP()} -> {h}")
             pal.SetTalentHP(h)
             self.handleMaxHealthUpdates(pal)
+            self.refresh()
 
         if self.meleevar.dirty:
             self.meleevar.dirty = False
             a = self.meleevar.get()
             print(f"{pal.GetFullName()}: AttackMelee {pal.GetAttackMelee()} -> {a}")
             pal.SetAttackMelee(a)
+            self.refresh()
 
         if self.shotvar.dirty:
             self.shotvar.dirty = False
             r = self.shotvar.get()
             print(f"{pal.GetFullName()}: AttackRanged {pal.GetAttackRanged()} -> {r}")
             pal.SetAttackRanged(r)
+            self.refresh()
 
         if self.defvar.dirty:
             self.defvar.dirty = False
             d = self.defvar.get()
             print(f"{pal.GetFullName()}: Defence {pal.GetDefence()} -> {d}")
             pal.SetDefence(d)
+            self.refresh()
 
         if self.wspvar.dirty:
             self.wspvar.dirty = False
             w = self.wspvar.get()
             print(f"{pal.GetFullName()}: WorkSpeed {pal.GetWorkSpeed()} -> {w}")
             pal.SetWorkSpeed(w)
+            self.refresh()
+
 
     def takelevel(self):
         if not self.isPalSelected():

--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -901,10 +901,9 @@ Do you want to use %s's DEFAULT Scaling (%s)?
         if pal.GetLevel() == 1:
             return
         lv = pal.GetLevel() - 1
-        self.handleMaxHealthUpdates(pal, changes={
-            'level': lv
-        })
+
         pal.SetLevel(lv)
+        self.handleMaxHealthUpdates(pal)
         self.refresh(i)
 
     def givelevel(self):
@@ -916,10 +915,9 @@ Do you want to use %s's DEFAULT Scaling (%s)?
         if pal.GetLevel() == 50:
             return
         lv = pal.GetLevel() + 1
-        self.handleMaxHealthUpdates(pal, changes={
-            'level': lv
-        })
+
         pal.SetLevel(lv)
+        self.handleMaxHealthUpdates(pal)
         self.refresh(i)
 
     def changespeciestype(self, evt):

--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -506,7 +506,7 @@ class PalEdit():
 
         if not pal.IsTower() and not pal.IsHuman():
             calc = pal.CalculateIngameStats()
-            self.hthstatval.config(text=calc["HP"])
+            self.hthstatval.config(text=pal.GetMaxHP())
             self.atkstatval.config(text=calc["ATK"])
             self.defstatval.config(text=calc["DEF"])
         else:

--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -470,7 +470,7 @@ class PalEdit():
 
         self.updateAttacks()
         self.refresh(i)
-
+        
     def onselect(self, evt):
         self.is_onselect = True
         w = evt.widget
@@ -506,7 +506,7 @@ class PalEdit():
 
         if not pal.IsTower() and not pal.IsHuman():
             calc = pal.CalculateIngameStats()
-            self.hthstatval.config(text=pal.GetMaxHP() / 1000)
+            self.hthstatval.config(text=math.floor(pal.GetMaxHP() / 1000))
             self.atkstatval.config(text=calc["ATK"])
             self.defstatval.config(text=calc["DEF"])
         else:
@@ -821,7 +821,7 @@ class PalEdit():
         newguid = uuid.uuid4()
         print(newguid)
 
-    def handleMaxHealthUpdates(self, pal: PalEntity, changes: dict):
+    def handleMaxHealthUpdates(self, pal: PalEntity):
         if not pal.IsTower() and not pal.IsHuman():
             pal.UpdateMaxHP()
 
@@ -854,6 +854,7 @@ Do you want to use %s's DEFAULT Scaling (%s)?
             return
 
         pal = self.palbox[self.players[self.current.get()]][self.editindex]
+        i = self.listdisplay.curselection()
         l = pal.GetLevel()
 
         if self.phpvar.dirty:
@@ -862,35 +863,35 @@ Do you want to use %s's DEFAULT Scaling (%s)?
             print(f"{pal.GetFullName()}: TalentHP {pal.GetTalentHP()} -> {h}")
             pal.SetTalentHP(h)
             self.handleMaxHealthUpdates(pal)
-            self.refresh()
+            self.refresh(i)
 
         if self.meleevar.dirty:
             self.meleevar.dirty = False
             a = self.meleevar.get()
             print(f"{pal.GetFullName()}: AttackMelee {pal.GetAttackMelee()} -> {a}")
             pal.SetAttackMelee(a)
-            self.refresh()
+            self.refresh(i)
 
         if self.shotvar.dirty:
             self.shotvar.dirty = False
             r = self.shotvar.get()
             print(f"{pal.GetFullName()}: AttackRanged {pal.GetAttackRanged()} -> {r}")
             pal.SetAttackRanged(r)
-            self.refresh()
+            self.refresh(i)
 
         if self.defvar.dirty:
             self.defvar.dirty = False
             d = self.defvar.get()
             print(f"{pal.GetFullName()}: Defence {pal.GetDefence()} -> {d}")
             pal.SetDefence(d)
-            self.refresh()
+            self.refresh(i)
 
         if self.wspvar.dirty:
             self.wspvar.dirty = False
             w = self.wspvar.get()
             print(f"{pal.GetFullName()}: WorkSpeed {pal.GetWorkSpeed()} -> {w}")
             pal.SetWorkSpeed(w)
-            self.refresh()
+            self.refresh(i)
 
 
     def takelevel(self):

--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -432,10 +432,9 @@ class PalEdit():
             1: 2,
         }
         new_rank = ranks.get(choice, 1)
-        self.handleMaxHealthUpdates(pal, changes={
-            'rank': new_rank
-        })
+
         pal.SetRank(new_rank)
+        self.handleMaxHealthUpdates(pal)
         self.refresh(i)
 
     def changeskill(self, num):

--- a/palworld_pal_edit/resources/data/pals.json
+++ b/palworld_pal_edit/resources/data/pals.json
@@ -1415,6 +1415,7 @@
                 "EPalWazaID::IcicleThrow": 50
             },
             "Scaling": {
+                "HP_BOSS": 420,
                 "HP": 140,
                 "ATK": 140,
                 "DEF": 120


### PR DESCRIPTION
### Issue:

- Frostallion is missing the boss hp scaling.
- maxhp calculated too early, and the stats panel is not displaying the true data
- ![image](https://github.com/EternalWraith/PalEdit/assets/38860226/d6563b5a-f700-4700-87ff-6b27e8bb311c)

### Fix:
- Frostallion is missing the boss hp scaling.
- MaxHP is calculated ahead of pal's rank/level/iv update
- Health Stat UI is not using the true save data

### Feat:
- display updated stats immediately after changes saved