### PR TITLE
fix player unicode name decoding exception while writing log

### DIFF
--- a/palworld_pal_edit/PalEditLogger.py
+++ b/palworld_pal_edit/PalEditLogger.py
@@ -5,7 +5,7 @@ class Logger:
     def __init__(self):
         if os.path.exists("log.txt"):
             os.remove("log.txt")
-        self.log = open("log.txt", "a", buffering=1)
+        self.log = open("log.txt", "a", encoding="UTF-8", buffering=1)
         self.WriteLog("= START OF LOG =")
 
     def WriteLog(self, string):


### PR DESCRIPTION
**Issue:**

- UnicodeEncodeError exception occurred while writing to log file with CP950 encoding that mentioned in #122 , #128

![image](https://github.com/EternalWraith/PalEdit/assets/36674765/be327daf-b5ee-4fd8-8f4d-d08c7928384d)

**Fix:**

- Open log file with utf-8 encoding


