### PR TITLE
Fix zh-CN wrong translation which mixed up Mine and Logging Foreman

### DIFF
--- a/palworld_pal_edit/resources/data/zh-CN/passives.json
+++ b/palworld_pal_edit/resources/data/zh-CN/passives.json
@@ -148,12 +148,12 @@
         "Description": "-20%防御力"
     },
     "TrainerMining_up1": {
-        "Name": "采伐领袖",
-        "Description": "+25%玩家伐木效率"
-    },
-    "TrainerLogging_up1": {
         "Name": "矿山首领",
         "Description": "+25%玩家采矿效率"
+    },
+    "TrainerLogging_up1": {
+        "Name": "采伐领袖",
+        "Description": "+25%玩家伐木效率"
     },
     "TrainerATK_UP_1": {
         "Name": "突袭指挥官",


### PR DESCRIPTION
zh-CN translation mixed up Mine Foreman and Logging Foreman.
Mine Foreman (TrainerMining_up1) is 矿山首领.
Logging Foreman (TrainerLogging_up1) is 采伐领袖.

Thank you for developing this tool.