### PR TITLE
[v0.8] New Unknown passives not debugging correctly

### DIFF
--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -570,7 +570,8 @@ class PalEdit():
 
         for i in range(0, 4):
             if not s[i] in [p for p in PalInfo.PalPassives]:
-                self.skills[i].set("Unknown")
+                self.skills[i].set("UNKNOWN")
+                print(s[i])
             else:
                 self.skills[i].set(s[i])
 
@@ -1262,9 +1263,58 @@ Do you want to use %s's DEFAULT Scaling (%s)?
 
         # tools.add_cascade(label="Converter", menu=convmenu, underline=0)
 
+
+
+# for i in paldata:
+#             try:
+#                 p = PalInfo.PalEntity(i)
+#                 if not str(p.owner) in self.palbox:
+#                     self.palbox[str(p.owner)] = []
+#                 self.palbox[str(p.owner)].append(p)
+
+#                 n = p.GetFullName()
+
+#                 for m in p.GetLearntMoves():
+#                     if not m in nullmoves:
+#                         if not m in PalInfo.PalAttacks:
+#                             nullmoves.append(m)
+#             except Exception as e:
+#                 if str(e) == "This is a player character":
+#                     logger.debug(f"Found Player Character")
+#                     # print(f"\nDebug: Data \n{i}\n\n")
+#                     # o = i['value']['RawData']['value']['object']['SaveParameter']['value']
+#                     # pl = "No Name"
+#                     # if "NickName" in o:
+#                     #     pl = o['NickName']['value']
+#                     # plguid = i['key']['PlayerUId']['value']
+#                     # print(f"{pl} - {plguid}")
+#                     # self.players[pl] = plguid
+#                 else:
+#                     self.unknown.append(str(e))
+#                     try:
+#                         erroredpals.append(i)
+#                     except:
+#                         erroredpals.append(None)
+#                     logger.error(f"Error occured on {i['key']['InstanceId']['value']}", exc_info=True)
+#                     # print(f"Error occured on {i['key']['InstanceId']['value']}: {e.__class__.__name__}: {str(e)}")
+#                     # traceback.print_exception(e)
+#                     print()
+#                 # print(f"Debug: Data {i}")
+
+
+
     def updateSkillsName(self):
         for idx, n in enumerate(self.skills):
-            self.skills_name[idx].set(PalInfo.PalPassives[n.get()])
+            try:
+                self.skills_name[idx].set(PalInfo.PalPassives[n.get()])
+            except Exception as e:
+                print(type(n))
+                # self.unknown.append(str(e))
+                # logger.error(f"Error occured on {i['key']['InstanceId']['value']}", exc_info=True)
+                #     # print(f"Error occured on {i['key']['InstanceId']['value']}: {e.__class__.__name__}: {str(e)}")
+                #     # traceback.print_exception(e)
+                # print()
+
 
     def changesoul(self, field):
         if not self.isPalSelected():

--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -133,6 +133,7 @@ class PalEditConfig:
 
 class PalEdit():
     ranks = (0, 1, 2, 3, 4)
+    debug_listPassivesSeen = set()
 
     def load_i18n(self, lang=""):
         path = f"{PalInfo.module_dir}/resources/data/en-GB/ui.json"
@@ -571,7 +572,8 @@ class PalEdit():
         for i in range(0, 4):
             if not s[i] in [p for p in PalInfo.PalPassives]:
                 self.skills[i].set("UNKNOWN")
-                print(s[i])
+                self.debug_listPassivesSeen.add(s[i])
+                print(self.debug_listPassivesSeen)
             else:
                 self.skills[i].set(s[i])
 

--- a/palworld_pal_edit/PalInfo.py
+++ b/palworld_pal_edit/PalInfo.py
@@ -106,7 +106,10 @@ class PalObject:
         if self._img == None:
             n = self.GetCodeName() if not self._human else "Human"
             # self._img = ImageTk.PhotoImage(Image.open(module_dir+f'/resources/{n}.png').resize((240,240)))
-            self._img = tkinter.PhotoImage(file=f'{module_dir}/resources/pals/{n}.png')
+            try:
+                self._img = tkinter.PhotoImage(file=f'{module_dir}/resources/pals/{n}.png')
+            except:
+                self._img = tkinter.PhotoImage(file=f'{module_dir}/resources/pals/Alpaca.png')
         return self._img
 
     def GetPrimary(self):

--- a/palworld_pal_edit/resources/data/attacks.json
+++ b/palworld_pal_edit/resources/data/attacks.json
@@ -11,6 +11,10 @@
         "Type": "Neutral",
         "Power": 25
     },
+    "EPalWazaID::Unique_WeaselDragon_FlyingTackle": {
+        "Type": "Dragon",
+        "Power": 50
+    },
     "EPalWazaID::Unique_Deer_PushupHorn": {
         "Type": "Neutral",
         "Power": 50,

--- a/palworld_pal_edit/resources/data/en-GB/attacks.json
+++ b/palworld_pal_edit/resources/data/en-GB/attacks.json
@@ -88,6 +88,7 @@
     "EPalWazaID::Unique_PinkCat_CatPunch": "Punch Flurry",
     "EPalWazaID::Unique_Boar_Tackle": "Reckless Charge",
     "EPalWazaID::RockLance": "Rock Lance",
+    "EPalWazaID::Unique_WeaselDragon_FlyingTackle": "Rocket Slam",
     "EPalWazaID::Unique_SheepBall_Roll": "Roly Poly",
     "EPalWazaID::MudShot": "Sand Blast",
     "EPalWazaID::SandTornado": "Sand Tornado",

--- a/palworld_pal_edit/resources/data/en-GB/pals.json
+++ b/palworld_pal_edit/resources/data/en-GB/pals.json
@@ -183,5 +183,11 @@
     "PalDealer_Desert": "Pal Merchant (Desert)",
     "PalDealer_Volcano": "Pal Merchant (Volcano)",
     "Police_Rifle": "PIDF Infantry",
-    "Police_Shotgun": "PIDF Elite"
+    "Police_Shotgun": "PIDF Elite",
+    "DarkAlien": "Xenovader",
+    "KendoFrog": "Croajiro",
+    "MimicDog": "Mimog",
+    "FeatherOstrich": "Dazemu",
+    "MushroomDragon": "Shroomer"
+
 }

--- a/palworld_pal_edit/resources/data/en-GB/passives.json
+++ b/palworld_pal_edit/resources/data/en-GB/passives.json
@@ -271,8 +271,48 @@
         "Name": "Infinite Stamina",
         "Description": "Max Stamina +50% (This effect is only valid for rideable pals.)"
     },
+    "SalePrice_Up_1": {
+        "Name": "Noble",
+        "Description": "+5% Sell price"
+    },
+    "CoolTimeReduction_Up_1": {
+        "Name": "Serenity",
+        "Description": "Active skill cooldown reduction 30% Attack +10% "
+    },
     "NonKilling": {
         "Name": "Mercy hit",
         "Description": "will not reduce the target's health below 1"
+    },
+    "SalePrice_Up_2": {
+        "Name": "Fine Furs",
+        "Description": "Sale price 3% "
+    },
+    "CoolTimeReduction_Up_2": {
+        "Name": "Impatient",
+        "Description": "Active skill cooldown reduction 15%"
+    },
+    "Stamina_Up_2": {
+        "Name": "Fit as a Fiddle",
+        "Description": "Max Stamina +25% (This effect is only valid for rideable pals.)"
+    },
+    "Nocturnal": {
+        "Name": "Nocturnal",
+        "Description": "The Pal does not sleep at night and continues to work. "
+    },
+    "SalePrice_Down_1": {
+        "Name": "Shabby",
+        "Description": "Sale price -10%"
+    },
+    "Test_PalEgg_HatchingSpeed_Up": {
+        "Name": "Philantropist",
+        "Description": "When assigned to a Breeding Farm, egg production time is reduced by 100%"
+    },
+    "Stamina_Down_1": {
+        "Name": "Sickly",
+        "Description": "-25% max Stamina"
+    },
+    "CoolTimeReduction_Down_1": {
+        "Name": "Easygoing",
+        "Description": "Active Skill Cooldown extension -15%"
     }
 }

--- a/palworld_pal_edit/resources/data/en-GB/passives.json
+++ b/palworld_pal_edit/resources/data/en-GB/passives.json
@@ -267,6 +267,10 @@
         "Name": "Siren of the Void",
         "Description": "+20% damage dealt with Ice and Dark attacks; Bellanoir Libero's signature ability"
     },
+    "Stamina_Up_1": {
+        "Name": "Infinite Stamina",
+        "Description": "Max Stamina +50% (This effect is only valid for rideable pals.)"
+    },
     "NonKilling": {
         "Name": "Mercy hit",
         "Description": "will not reduce the target's health below 1"

--- a/palworld_pal_edit/resources/data/pals.json
+++ b/palworld_pal_edit/resources/data/pals.json
@@ -4510,11 +4510,13 @@
             "Moveset": {
                 "EPalWazaID::IceMissile": 1,
                 "EPalWazaID::DragonCanon": 7,
+                "EPalWazaID::Unique_WeaselDragon_FlyingTackle": 11,
                 "EPalWazaID::DragonWave": 15,
                 "EPalWazaID::IceBlade": 22,
                 "EPalWazaID::DragonBreath": 30,
                 "EPalWazaID::FrostBreath": 40,
                 "EPalWazaID::DragonMeteor": 50
+                
             },
             "Scaling": {
                 "HP": 90,
@@ -5007,6 +5009,151 @@
                 "ProductMedicine": 4,
                 "Cool": 0,
                 "Transport": 2,
+                "MonsterFarm": 0
+            }
+        },
+        {
+            "CodeName": "DarkAlien",
+            "Type": [
+                "Dark"
+            ],
+            "Moveset": {
+                
+            },
+            "Scaling": {
+                "HP": 90,
+                "ATK": 125,
+                "DEF": 85
+            },
+            "Suitabilities": {
+                "EmitFlame": 0,
+                "Watering": 0,
+                "Seeding": 0,
+                "GenerateElectricity": 0,
+                "Handcraft": 0,
+                "Collection": 0,
+                "Deforest": 2,
+                "Mining": 0,
+                "OilExtraction": 0,
+                "ProductMedicine": 0,
+                "Cool": 0,
+                "Transport": 2,
+                "MonsterFarm": 0
+            }
+        },
+        {
+            "CodeName": "MimicDog",
+            "Type": [
+                "Neutral"
+            ],
+            "Moveset": {
+                
+            },
+            "Scaling": {
+                "HP": 60,
+                "ATK": 60,
+                "DEF": 130
+            },
+            "Suitabilities": {
+                "EmitFlame": 0,
+                "Watering": 0,
+                "Seeding": 0,
+                "GenerateElectricity": 0,
+                "Handcraft": 0,
+                "Collection": 1,
+                "Deforest": 0,
+                "Mining": 0,
+                "OilExtraction": 0,
+                "ProductMedicine": 0,
+                "Cool": 0,
+                "Transport": 0,
+                "MonsterFarm": 0
+            }
+        },
+        {
+            "CodeName": "KendoFrog",
+            "Type": [
+                "Water"
+            ],
+            "Moveset": {
+                
+            },
+            "Scaling": {
+                "HP": 80,
+                "ATK": 80,
+                "DEF": 80
+            },
+            "Suitabilities": {
+                "EmitFlame": 0,
+                "Watering": 1,
+                "Seeding": 0,
+                "GenerateElectricity": 0,
+                "Handcraft": 1,
+                "Collection": 1,
+                "Deforest": 0,
+                "Mining": 0,
+                "OilExtraction": 0,
+                "ProductMedicine": 0,
+                "Cool": 0,
+                "Transport": 1,
+                "MonsterFarm": 0
+            }
+        },
+        {
+            "CodeName": "FeatherOstrich",
+            "Type": [
+                "Ground"
+            ],
+            "Moveset": {
+                
+            },
+            "Scaling": {
+                "HP": 80,
+                "ATK": 80,
+                "DEF": 80
+            },
+            "Suitabilities": {
+                "EmitFlame": 0,
+                "Watering": 0,
+                "Seeding": 0,
+                "GenerateElectricity": 0,
+                "Handcraft": 0,
+                "Collection": 2,
+                "Deforest": 0,
+                "Mining": 0,
+                "OilExtraction": 0,
+                "ProductMedicine": 0,
+                "Cool": 0,
+                "Transport": 0,
+                "MonsterFarm": 0
+            }
+        },
+        {
+            "CodeName": "MushroomDragon",
+            "Type": [
+                "Grass"
+            ],
+            "Moveset": {
+                
+            },
+            "Scaling": {
+                "HP": 80,
+                "ATK": 80,
+                "DEF": 80
+            },
+            "Suitabilities": {
+                "EmitFlame": 0,
+                "Watering": 0,
+                "Seeding": 2,
+                "GenerateElectricity": 0,
+                "Handcraft": 1,
+                "Collection": 2,
+                "Deforest": 2,
+                "Mining": 0,
+                "OilExtraction": 0,
+                "ProductMedicine": 0,
+                "Cool": 0,
+                "Transport": 0,
                 "MonsterFarm": 0
             }
         },

--- a/palworld_pal_edit/resources/data/passives.json
+++ b/palworld_pal_edit/resources/data/passives.json
@@ -200,6 +200,9 @@
     "Witch": {
         "Rating": "Good"
     },
+    "Stamina_Up_1": {
+        "Rating": "Good"
+    },
     "NonKilling": {
         "Rating": "Bad"
     }

--- a/palworld_pal_edit/resources/data/passives.json
+++ b/palworld_pal_edit/resources/data/passives.json
@@ -203,6 +203,37 @@
     "Stamina_Up_1": {
         "Rating": "Good"
     },
+    "SalePrice_Up_1": {
+        "Rating": "Good"
+    },
+    "CoolTimeReduction_Up_1": {
+        "Rating": "Good"
+    },
+
+    "SalePrice_Up_2": {
+        "Rating": "Good"
+    },
+    "CoolTimeReduction_Up_2": {
+        "Rating": "Good"
+    },
+    "Stamina_Up_2": {
+        "Rating": "Good"
+    },
+    "Nocturnal": {
+        "Rating": "Good"
+    },
+    "SalePrice_Down_1": {
+        "Rating": "Bad"
+    },
+    "Test_PalEgg_HatchingSpeed_Up": {
+        "Rating": "Good"
+    },
+    "CoolTimeReduction_Down_1": {
+        "Rating": "Bad"
+    },
+    "Stamina_Down_1": {
+        "Rating": "Bad"
+    },
     "NonKilling": {
         "Rating": "Bad"
     }


### PR DESCRIPTION
The new passives are Unknown to the tool, which is fine. However, when launching the tool it sometimes doesn't update the Passives list if the new passive isn't there. Intended behavior seems to be that it should display 'Unknown' where the unknown passive is.

In the logs, it Raises a KeyError and the function fails to execute.

```
Traceback (most recent call last):
  File "C:\Users\*****\anaconda3\envs\Paledit\Lib\tkinter\__init__.py", line 1968, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
  File "D:\workspace\paledit\PalEdit\palworld_pal_edit\PalEdit.py", line 580, in onselect
    self.setskillcolours()
  File "D:\workspace\paledit\PalEdit\palworld_pal_edit\PalEdit.py", line 970, in setskillcolours
    rating = PalInfo.PassiveRating[self.skills[snum].get()]
             ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'Unknown'
```

This is because in passive setting command, it is looking for the keyword 'UNKNOWN' rather than the 'Unknown' that PalEdit::onselect() provides. on line 573:

 ```       for i in range(0, 4):
            if not s[i] in [p for p in PalInfo.PalPassives]:
                self.skills[i].set("Unknown")
                print(s[i])
            else:
                self.skills[i].set(s[i])
```

By changing "Unknown -> "UNKNOWN" on line 57s a large portion of the runtime errors will be fixed and unknown skills will properly display as unknown, rather than not updating. This appears to be causing the inability to save as well.

Unfortunately, I am not super experienced in github so this comes with a bunch of random additions that i made when trying to debug the issue.

Thanks,
augentism