### PR TITLE
If your dedicated sav file cannot be loaded, please read this

### DIFF
--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -673,8 +673,14 @@ class PalEdit():
         print(self.players)
         for p in self.players:
             playerguid = self.players[p]
-            playersav = os.path.dirname(self.filename) + f"/Players/{str(playerguid).upper().replace('-', '')}.sav"
-            self.players[p] = PalInfo.PalPlayerEntity(palworld_pal_edit.SaveConverter.convert_sav_to_obj(playersav))
+            try:
+                playersav = os.path.dirname(self.filename) + f"/Players/{str(playerguid).upper().replace('-', '')}.sav"
+                self.players[p] = PalInfo.PalPlayerEntity(palworld_pal_edit.SaveConverter.convert_sav_to_obj(playersav))
+            except FileNotFoundError:
+                # hard coding here to get the player name
+                playersav = os.path.dirname(self.filename) + f"/Players/BA77AF22000000000000000000000000.sav"
+                self.players[p] = PalInfo.PalPlayerEntity(palworld_pal_edit.SaveConverter.convert_sav_to_obj(playersav))
+
         self.containers = {}
         nullmoves = []
 


### PR DESCRIPTION
If your dedicated save file cannot be read, please modify this section.

The players' save file may not match the UUID if the HOST has used a save conversion tool. I’ve hardcoded a solution and opened a PR for anyone who wants to quickly fix this issue—you’ll be able to see exactly where to make the change.

