### PR TITLE
feat: add safe Level.sav editing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## ✨ What's new in the 1.0 update
 
-- 🐣 **Palworld 1.0 - GlobalPalBox support** — reads & writes the new save format, loads the **Global Palbox** (`GlobalPalStorage.sav`), refreshed 1.0 species / moves / passives / icons, level cap raised to 80.
+- 🐣 **Palworld 1.0 save support** — reads and writes the **Global Palbox** (`GlobalPalStorage.sav`) and world saves (`Level.sav`), with refreshed 1.0 species, moves, passives and icons, plus a level cap of 80.
 - 🛡️ **Save-safe** — opening a file and saving it back changes *nothing* unless you actually edit something (verified with a field-by-field comparison of every pal). It also tidies up leftover data from earlier versions — including the issue that made unassigned pals idly **"graze"** and produce nothing.
 - 📦 **Global Palbox management** — **add, clone, delete, and rename** pals right in the box.
 - 🔎 **Searchable everything:**
@@ -36,7 +36,7 @@
 - 💾 **Automatic per-session backups** — your save is copied to a `PalEdit-backups` folder before the first write.
 
 > [!TIP]
-> Editing focus so far has been the **Global Palbox**. As with any save editor, keep your own backups too. NPC/merchant editing works inside PalEdit but using them in-game is still experimental.
+> PalEdit supports both the **Global Palbox** and local world Pals. As with any save editor, keep your own backups too. NPC/merchant editing works inside PalEdit but using them in-game is still experimental.
 
 > ⚠️ **Before Opening a new Issue**: Please check the [**🚧 Project roadmap**](#-project-roadmap) section to ensure that your concern or feature request hasn't already been addressed or is planned for a future release. Also check the [Open Issues](https://github.com/EternalWraith/PalEdit/issues).
 
@@ -62,27 +62,28 @@ Download the compiled executable from [Releases Page](https://github.com/TheMyst
 
 ## **🕹️ Usage**
 
-This fork focuses on your **Global Palbox** — the shared Pal storage you reach
-through the *Pal Genetic Data* terminal in-game.
+This fork supports the shared **Global Palbox** and the local Pals stored in a
+world's `Level.sav`.
 
 > [!IMPORTANT]
-> **The Global Palbox (`GlobalPalStorage.sav`) is the only save file tested and
-> working right now.** Editing a world's `Level.sav` isn't enabled yet — the
-> groundwork and the remaining steps are written up in
-> [docs/save-editing-analysis.md](docs/save-editing-analysis.md). Please stick to
-> the Global Palbox for now, and keep a backup.
+> Close Palworld before loading either save. For `Level.sav`, keep the matching
+> `Players` folder beside it. PalEdit uses those player saves to resolve each
+> player's party and Palbox containers. Players whose file is missing remain
+> visible, but their local Pals cannot be cloned or imported safely. PalEdit
+> rejects save files whose compressed or decompressed data exceeds 512 MiB.
 
 ![The PalEdit window editing a Pal in the Global Palbox](docs/images/paledit-window.png)
 
 1. **Download & run.** Grab the latest build from the [Releases page](https://github.com/TheMysticTurtle/PalEdit/releases), extract the zip into a folder anywhere, and run **`PalEdit.exe`**.
-2. **Load your save.** Choose **File → Load Save** and open your **`GlobalPalStorage.sav`**. On Windows it lives at:
+2. **Load your save.** Choose **File → Load Save** and open either your
+   **`GlobalPalStorage.sav`** or a world's **`Level.sav`**. On Windows they live under:
 
     ```
-    %LocalAppData%\Pal\Saved\SaveGames\<your-account-id>\GlobalPalStorage.sav
+    %LocalAppData%\Pal\Saved\SaveGames\<your-account-id>\
     ```
 
     (there's one numbered folder per account — see [Backing up your save](#-backing-up-your-save) for how to find it.)
-3. **Edit away.** You'll see every Pal in your Global Palbox. Select one to change its level, stats/IVs, souls, moves, passives, nickname or species, or use **Add New Pal**, **Clone Pal** and **Delete Pal** to manage the box (see [Adding, cloning & deleting Pals](#-adding-cloning--deleting-pals)).
+3. **Edit away.** In a world save, choose a player to see that player's party and local Palbox. Select a Pal to change its level, stats/IVs, souls, moves, passives, nickname or species. **Clone Pal** and **Delete Pal** update the character, container and guild references together. **Add New Pal** imports a Pal JSON exported from PalEdit into the selected player's Palbox.
 4. **Save.** Choose **File → Save**. The first save of each session automatically copies your original file into a `PalEdit-backups` folder next to it, just in case.
 5. **Pick your changes up in-game** — see below.
 
@@ -138,6 +139,12 @@ Right in the Global Palbox, next to the portrait:
 - **Add New Pal** — drops a fresh Pal into the box (it starts as a default species; change it with the **Species** picker, then edit its level, moves, passives and stats to taste).
 - **Delete Pal** — clears the selected slot after a confirmation.
 
+In `Level.sav`, **Clone Pal** places the copy in the selected player's first free
+Palbox slot. **Delete Pal** removes the selected Pal from its current party,
+Palbox or base container and from its guild handle list. **Add New Pal** opens an
+exported Pal JSON and imports the whole batch only if every Pal fits. A failed
+preflight leaves the world unchanged.
+
 Cloned and newly added Pals arrive through the same in-game flow as above: drag them
 onto an empty slot in a local box, wait out the short reconstruction cooldown, and
 they're ready to go.
@@ -153,8 +160,9 @@ On Windows, the saves can be found here:
 
 - `%LocalAppData%\Pal\Saved\SaveGames\`
 
-You'll find one folder per account (a long numbered name); your **`GlobalPalStorage.sav`**
-is inside it.
+You'll find one folder per account (a long numbered name). The Global Palbox is
+stored there. Each world folder contains `Level.sav` and its matching `Players`
+folder.
 
 If you’ve installed Palworld via Steam, you can also access your save files by following these steps:
 
@@ -231,6 +239,7 @@ If you’ve installed Palworld via Steam, you can also access your save files by
   - [x] Work suitabilities 0–10 with colour feedback
   - [x] Custom named passive presets
   - [x] Save-safety fixes (no-edit open→save is a no-op; tidies leftover data)
+  - [x] Full `Level.sav` support with player filtering and reference-safe import, clone and delete
 
 - **Still pending / help wanted:**
   - [ ] Add update notification if a newer version is found

--- a/docs/save-editing-analysis.md
+++ b/docs/save-editing-analysis.md
@@ -1,8 +1,7 @@
 # Palworld save editing — developer analysis
 
-This note documents how this fork reads and writes Palworld **1.0** save files,
-which files are supported today, and what a full **world save (`Level.sav`)**
-editor would still need. It's aimed at contributors; end-user instructions live
+This note documents how this fork reads and writes Palworld **1.0** save files
+and the integrity rules used for **world save (`Level.sav`)** editing. It's aimed at contributors; end-user instructions live
 in the [README](../README.md).
 
 Reference implementations consulted throughout:
@@ -45,12 +44,12 @@ marks the large, editor-irrelevant world maps as `(skip_decode, skip_encode)`:
   `ItemContainerSaveData`.
 
 It intentionally **decodes** the maps it works with: `CharacterSaveParameterMap`
-(the pals), `CharacterContainerSaveData` (box/slot placement) and — historically
-— `GroupSaveDataMap` (guilds). See §5 for why the last one is now a problem.
+(the pals), `CharacterContainerSaveData` (box/slot placement) and
+`GroupSaveDataMap` (guilds).
 
 ## 3. `GlobalPalStorage.sav` — the Global Palbox (supported)
 
-This is the file the fork targets and the only one verified end-to-end.
+This file remains the simplest editing path and is verified end-to-end.
 
 - Top-level property is a flat `SaveParameterArray` of **960 slots**; each slot
   is `{ SaveParameter, InstanceId }`. An empty slot has `CharacterID == "None"`
@@ -85,60 +84,49 @@ Handled in `PalInfo.PalEntity`. The 1.0-specific points that bit us:
   against species data case-insensitively (Unreal FNames ignore case), so e.g.
   the game's `SheepBall` resolves to a data key stored as `Sheepball`.
 
-## 5. `Level.sav` — world saves (analysis; not yet enabled)
+## 5. `Level.sav` world saves
 
-The world-save code path exists (`loaddata`'s non-storage branch +
-`PalInfo.PalGuid`) and is structurally aligned with 1.0: same
-`worldSaveData.CharacterSaveParameterMap` / `CharacterContainerSaveData` /
-`GroupSaveDataMap`, same player/pal model.
+The vendored `rawdata/group.py` decoder now handles both pre-update and
+post-update guild tails, including markers, chest roles, player roles,
+permissions and trailing bytes. PalEdit therefore keeps
+`CharacterSaveParameterMap`, `CharacterContainerSaveData` and
+`GroupSaveDataMap` decoded while editing.
 
-### The one blocker
+World writes use these rules:
 
-Loading a real 1.0 `Level.sav` fails while **decoding `GroupSaveDataMap`**:
+1. A new or cloned Pal receives a fresh instance GUID and the first free index
+   below the target container's `SlotNum`.
+2. The character-map entry, character-container slot and guild handle are
+   added together. Batch imports preflight every source and available slot.
+3. Deletion proceeds only when the character's `SlotId` agrees with a container
+   slot holding the same instance GUID. It then removes the matching guild
+   handle and character entry.
+4. Missing `Players/<guid>.sav` files disable import and clone for that player.
+   PalEdit does not guess a Palbox container.
+5. Before replacing the file, PalEdit serializes, compresses, decompresses and
+   reparses the generated save. It writes through a same-folder temporary file,
+   verifies that the loaded target has not changed, and atomically replaces it.
+   As with other portable compare-then-replace workflows, an uncooperative
+   writer could still race in the narrow interval between verification and
+   replacement.
+6. PalEdit caps both compressed save input and decompressed GVAS output at
+   512 MiB. The zlib decoder enforces the output cap while expanding data, and
+   the Oodle decoder rejects an oversized declared output length before native
+   allocation. The same limits apply to matching player saves.
 
-```
-palworld_save_tools/rawdata/group.py -> Exception("Warning: EOF not reached")
-```
-
-1.0 appended trailing bytes to each guild entry that the vendored decoder
-doesn't consume (psp handles this in `guild.rs` + `guild_tail.rs`). Everything
-else — compression, all other maps, the per-pal model — already works.
-
-### The minimal fix (proven, not yet merged)
-
-Add `.worldSaveData.GroupSaveDataMap` to the skip-decode set. The guild data is
-then preserved as raw bytes and written back verbatim. With only that change, a
-real 1.0 world fixture loaded **every pal (~2,150) and all 10 players** and
-completed a no-edit save round-trip.
-
-Verified against psp's fixtures:
-`psp-reference/tests/fixtures/saves/v1_relics/` (and `v1_stats`,
-`reference_saves`) — real 1.0 `Level.sav` files with a `Players/` folder.
-
-### Trade-offs to resolve before shipping world support
-
-1. **Guild-dependent writes.** `PalGuid`'s group helpers
-   (`AddGroupSaveData`, …), used by world-mode clone/add to register a new pal
-   in a guild, can't run against raw-bytes groups. Editing *existing* world
-   pals is unaffected; adding/cloning into a world would need those paths
-   guarded (or the full guild parser, below).
-2. **Performance.** GVAS parsing is pure Python; the 2.3 MB test world is fine,
-   but a large real world may be slow.
-
-### Fuller option
-
-Port psp's 1.0 guild parsing (`guild.rs` + `guild_tail.rs`) into a Python
-`rawdata/group.py` decoder. This restores full guild editing (including
-world-mode add/clone) at the cost of a nontrivial binary-format port.
+The implementation is verified against psp's public
+`tests/fixtures/saves/v1_relics/Level.sav`. That fixture contains 2,167
+character entries, 67 character containers, 17 groups and 17 players. A
+clone reparses with all three new references. Deleting that clone restores the
+original uncompressed GVAS bytes exactly.
 
 ## 6. Status summary
 
 | Save file                | Load | Edit existing | Add / clone | Notes |
 |--------------------------|------|---------------|-------------|-------|
 | `GlobalPalStorage.sav`   | ✅   | ✅            | ✅          | Fully supported & round-trip verified |
-| `Level.sav` (world)      | ⛔→✅* | ✅*          | ⚠️          | *with the §5 skip-decode fix; add/clone needs guild handling |
+| `Level.sav` (world)      | ✅   | ✅            | ✅          | Reference-safe import, clone and delete; round-trip verified |
 | `Players/<guid>.sav`     | ✅   | n/a           | n/a         | Loaded for player names in world mode |
 
-The Global Palbox is the tested, recommended path today. World-save support is
-diagnosed and a small change away from loading + editing existing pals; it's
-left off until the trade-offs in §5 are handled.
+Both save paths are supported. Keep the matching `Players` folder beside a
+world save and retain backups of the whole world directory.

--- a/palworld_pal_edit/PalEdit.py
+++ b/palworld_pal_edit/PalEdit.py
@@ -1,4 +1,4 @@
-import os, webbrowser, json, time, uuid, math, zipfile, shutil
+import os, webbrowser, json, time, uuid, math, zipfile, shutil, tempfile, hashlib
 
 import pyperclip
 
@@ -118,6 +118,88 @@ PALEDIT_PALWORLD_CUSTOM_PROPERTIES[".worldSaveData.DynamicItemSaveData"] = (skip
 #PALEDIT_PALWORLD_CUSTOM_PROPERTIES[".worldSaveData.CharacterContainerSaveData"] = (skip_decode, skip_encode)
 PALEDIT_PALWORLD_CUSTOM_PROPERTIES[".worldSaveData.ItemContainerSaveData"] = (skip_decode, skip_encode)
 #PALEDIT_PALWORLD_CUSTOM_PROPERTIES[".worldSaveData.GroupSaveDataMap"] = (skip_decode, skip_encode)
+
+
+MAX_PAL_IMPORT_BYTES = 64 * 1024 * 1024
+MAX_SAVE_FILE_BYTES = 512 * 1024 * 1024
+
+
+def load_pal_import(filename, max_bytes=MAX_PAL_IMPORT_BYTES):
+    """Read a Pal JSON export without allowing an unbounded allocation."""
+    with open(filename, "rb") as source_file:
+        payload = source_file.read(max_bytes + 1)
+    if len(payload) > max_bytes:
+        raise ValueError("The Pal import file is too large.")
+    return json.loads(payload)
+
+
+def read_bounded_file(filename, max_bytes=MAX_SAVE_FILE_BYTES):
+    """Read a save with both pre-read and growing-file size checks."""
+    if os.path.getsize(filename) > max_bytes:
+        raise ValueError("The save file is too large.")
+    with open(filename, "rb") as source_file:
+        payload = source_file.read(max_bytes + 1)
+    if len(payload) > max_bytes:
+        raise ValueError("The save file is too large.")
+    return payload
+
+
+def validate_player_save_identity(player, expected_guid):
+    if str(player.GetPlayerGuid()).lower() != str(expected_guid).lower():
+        raise ValueError("The player save identity does not match its world player GUID.")
+
+
+def serialize_and_validate_save(gvas_file, save_type):
+    """Serialize, recompress, decompress, and reparse before a save can replace disk data."""
+    raw_gvas = gvas_file.write(PALEDIT_PALWORLD_CUSTOM_PROPERTIES)
+    sav_file = compress_gvas_to_sav(raw_gvas, save_type)
+    checked_raw, checked_type = decompress_sav_to_gvas(
+        sav_file, max_output_size=MAX_SAVE_FILE_BYTES)
+    if checked_type != save_type or checked_raw != raw_gvas:
+        raise ValueError("The generated save failed its compression round-trip check.")
+    reparsed = GvasFile.read(
+        checked_raw, PALWORLD_TYPE_HINTS, PALEDIT_PALWORLD_CUSTOM_PROPERTIES)
+    if reparsed.trailer != b"\x00\x00\x00\x00":
+        raise ValueError("The generated save has an invalid GVAS trailer.")
+    if reparsed.write(PALEDIT_PALWORLD_CUSTOM_PROPERTIES) != checked_raw:
+        raise ValueError("The generated save failed its complete reparse check.")
+    return sav_file
+
+
+def file_digest(filename):
+    digest = hashlib.sha256()
+    with open(filename, "rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.digest()
+
+
+def atomic_write_save(filename, sav_file, expected_digest=None):
+    """Atomically replace a save after a last-moment generation check."""
+    directory = os.path.dirname(os.path.abspath(filename))
+    prefix = "." + os.path.basename(filename) + ".PalEdit."
+    descriptor, temporary = tempfile.mkstemp(
+        dir=directory, prefix=prefix, suffix=".tmp")
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(sav_file)
+            output.flush()
+            os.fsync(output.fileno())
+
+        if (
+                expected_digest is not None
+                and (
+                    not os.path.exists(filename)
+                    or file_digest(filename) != expected_digest
+                )
+        ):
+            raise RuntimeError(
+                "The save changed on disk while PalEdit was writing; nothing was replaced.")
+        os.replace(temporary, filename)
+    finally:
+        if os.path.exists(temporary):
+            os.remove(temporary)
+
 
 import traceback
 
@@ -927,6 +1009,17 @@ class PalEdit():
             return
         self.skilllabel.config(text=PalInfo.PassiveDescriptions[self.skills[num].get()])
 
+    def _clear_loaded_save_state(self):
+        self.filename = ""
+        self.loaded_file_digest = None
+        self.save_type = None
+        self.data = None
+        self.palguidmanager = None
+        self.palbox = []
+        self.players = {}
+        self.current.set("")
+        self.disable_menus()
+
     def loadfile(self):
         self.skilllabel.config(text=self.i18n['msg_saving'])
 
@@ -937,19 +1030,30 @@ class PalEdit():
         logger.info(f"Opening file {file}")
 
         if file:
-            self.filename = file
-            self.gui.title(f"PalEdit v{PalEditConfig.version} - {file}")
-            self.skilllabel.config(text=self.i18n['msg_decompressing'])
-            with open(file, "rb") as f:
-                data = f.read()
-                raw_gvas, self.save_type = decompress_sav_to_gvas(data)
-            self.skilllabel.config(text=self.i18n['msg_loading'])
-            
+            self._clear_loaded_save_state()
+            self.gui.title(f"PalEdit v{PalEditConfig.version}")
             try:
+                self.skilllabel.config(text=self.i18n['msg_decompressing'])
+                data = read_bounded_file(file)
+                candidate_digest = hashlib.sha256(data).digest()
+                raw_gvas, candidate_save_type = decompress_sav_to_gvas(
+                    data, max_output_size=MAX_SAVE_FILE_BYTES)
+                self.skilllabel.config(text=self.i18n['msg_loading'])
                 gvas_file = GvasFile.read(raw_gvas, PALWORLD_TYPE_HINTS, PALEDIT_PALWORLD_CUSTOM_PROPERTIES)
+            except Exception as e:
+                self.logerror(str(e))
+                return
+
+            self.filename = file
+            self.loaded_file_digest = candidate_digest
+            self.save_type = candidate_save_type
+            self.gui.title(f"PalEdit v{PalEditConfig.version} - {file}")
+            try:
                 self.loaddata(gvas_file)
             except Exception as e:
-                self.logerror(str(e))           
+                self._clear_loaded_save_state()
+                self.gui.title(f"PalEdit v{PalEditConfig.version}")
+                self.logerror(str(e))
             # self.doconvertjson(file, (not self.debug))
         else:
             messagebox.showerror(self.i18n['select_file'], self.i18n['msg_select_save_file'])
@@ -1030,7 +1134,13 @@ class PalEdit():
                 playerguid = self.players[p]
                 playersav = os.path.dirname(self.filename) + f"/Players/{str(playerguid).upper().replace('-', '')}.sav"
                 try:
-                    self.players[p] = PalInfo.PalPlayerEntity(palworld_pal_edit.SaveConverter.convert_sav_to_obj(playersav))
+                    player = PalInfo.PalPlayerEntity(
+                        palworld_pal_edit.SaveConverter.convert_sav_to_obj(
+                            playersav,
+                            max_input_bytes=MAX_SAVE_FILE_BYTES,
+                            max_output_size=MAX_SAVE_FILE_BYTES))
+                    validate_player_save_identity(player, playerguid)
+                    self.players[p] = player
                 except Exception:
                     logger.error(f"Could not load player save {playersav}", exc_info=True)
                     self.players[p] = PalInfo.PalStoragePlayer(playerguid)
@@ -1073,10 +1183,11 @@ class PalEdit():
                     print()
                 # print(f"Debug: Data {i}")
 
-        self.current.set(next(iter(self.players)))
-        logger.info(f"Defaulted selection to {self.current.get()}")
-
-        self.updateDisplay()
+        if self._configure_player_selection():
+            self.updateDisplay()
+        else:
+            self.listdisplay.delete(0, tk.constants.END)
+            self.playerguid.config(text="")
 
         logger.Space()
         logger.info(f"NOTE: Unknown list is a list of pals that could not be loaded")
@@ -1095,8 +1206,6 @@ class PalEdit():
         logger.debug(f"{len(self.players)} players found:")
         for i in self.players:
             logger.debug(f"{i} = {self.players[i]}")
-        self.playerdrop['values'] = list(self.players.keys())
-        self.playerdrop.current(0)
         logger.Space()
 
         if False:  # change to true to enable testing of containers
@@ -1130,8 +1239,24 @@ class PalEdit():
         self.gui.focus_force()
         self.gui.bell()
 
+    def _configure_player_selection(self):
+        names = list(self.players.keys())
+        self.playerdrop['values'] = names
+        if not names:
+            self.current.set("")
+            self.playerdrop.config(state="disabled")
+            return False
+        self.current.set(names[0])
+        self.playerdrop.config(state="readonly")
+        self.playerdrop.current(0)
+        logger.info(f"Defaulted selection to {self.current.get()}")
+        return True
+
     def updateDisplay(self):
         self.listdisplay.delete(0, tk.constants.END)
+        if self.current.get() not in self.players:
+            self.playerguid.config(text="")
+            return
         currentguid = self.players[self.current.get()].GetPlayerGuid()
 
         self.playerguid.config(text=currentguid)
@@ -1154,7 +1279,11 @@ class PalEdit():
 
     def logerror(self, msg):
         logger.WriteLog(msg)
-        messagebox.showinfo("Error", "There was an error! Your save may have issues or the tool is unable to process it. Upload your log.txt file to the support channel in our discord and ask for help.")
+        messagebox.showinfo(
+            "Error",
+            "PalEdit did not write the save.\n\n"
+            f"Details: {msg}\n\n"
+            "If you need help, upload log.txt to the support channel.")
 
     def backup_save(self, file):
         """Copy the on-disk save into a PalEdit-backups folder next to it,
@@ -1193,6 +1322,7 @@ class PalEdit():
         # print(file, self.filename)
         if file:
             logger.info(f"Opening file {file}")
+            expected_digest = self.loaded_file_digest
             # Preserve the current on-disk save before the first write of this
             # session; abort the save entirely if the backup cannot be made.
             if not self.backup_save(file):
@@ -1213,12 +1343,9 @@ class PalEdit():
                             save_type = 0x32
                         else:
                             save_type = 0x31
-                    sav_file = compress_gvas_to_sav(
-                        gvas_file.write(PALEDIT_PALWORLD_CUSTOM_PROPERTIES), save_type
-                    )
+                    sav_file = serialize_and_validate_save(gvas_file, save_type)
                     self.skilllabel.config(text=self.i18n['msg_writing'])
-                    with open(file, "wb") as f:
-                        f.write(sav_file)
+                    atomic_write_save(file, sav_file, expected_digest=expected_digest)
                     self.data = None
                     self.current.set("")
                     self.palbox = {}
@@ -1229,6 +1356,8 @@ class PalEdit():
                     self.doconvertsave(file)
             except Exception as e:
                 self.logerror(str(e))
+                self.skilllabel.config(text=self.i18n['msg_saving'])
+                return
 
             self.changetext(-1)
             self.jump()
@@ -1315,6 +1444,8 @@ Do you want to use %s's DEFAULT Scaling (%s)?
 
         if getattr(self, 'storage_mode', False):
             filterlist = list(self.palbox)
+        elif self.current.get() not in self.players:
+            filterlist = []
         else:
             filtered = filter(GetMyPals, self.palbox)
             filterlist = list(filtered)
@@ -1954,52 +2085,56 @@ Do you want to use %s's DEFAULT Scaling (%s)?
         self.doconvertjson(file)
 
     def spawnpal(self):
-        print(self.palguidmanager)
-        if not self.isPalSelected() or self.palguidmanager is None:
+        if (
+                self.palguidmanager is None
+                or self.current.get() not in self.players
+        ):
             return
-
-        
-        
-        playerguid = self.players[self.current.get()].GetPlayerGuid()
-        playersav = os.path.dirname(self.filename) + f"/Players/{str(playerguid).upper().replace('-', '')}.sav"
-        if not os.path.exists(playersav):
-            print("Cannot Load Player Save!")
-            return
-        player = PalInfo.PalPlayerEntity(palworld_pal_edit.SaveConverter.convert_sav_to_obj(playersav))
-        palworld_pal_edit.SaveConverter.convert_obj_to_sav(player.dump(), playersav + ".bak", True)
 
         file = askopenfilename(filetypes=[("json files", "*.json")])
         if file == '':
             messagebox.showerror(self.i18n['select_file'], self.i18n['msg_select_save_file'])
             return
 
-        f = open(file, "r", encoding="utf8")
-        spawnpaldata = json.loads(f.read())
-        f.close()
-
-        slotguid = str(player.GetPalStorageGuid())
+        player = self.players[self.current.get()]
+        playerguid = player.GetPlayerGuid()
+        slotguid = player.GetPalStorageGuid()
         groupguid = self.palguidmanager.GetGroupGuid(playerguid)
-        if any(guid == None for guid in [slotguid, groupguid]):
+        if any(guid is None for guid in [playerguid, slotguid, groupguid]):
+            messagebox.showerror(
+                "Cannot import Pal",
+                "The selected player's Players/*.sav file or guild/container data is missing.")
             return
-        for p in spawnpaldata['Pals']:
-            newguid = str(uuid.uuid4())
-            pal = PalInfo.PalEntity(p)
-            i = self.palguidmanager.GetEmptySlotIndex(slotguid)
-            if i == -1:
-                print("Player Pal Storage is full!")
-                return
 
+        try:
+            spawnpaldata = load_pal_import(file)
+            pals = spawnpaldata['Pals']
+            if not isinstance(pals, list) or not pals:
+                raise ValueError("The file contains no Pals.")
+        except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as e:
+            messagebox.showerror("Cannot import Pal", str(e))
+            return
+
+        owner_uids = []
+        for source in pals:
+            try:
+                source_owner = source['key']['PlayerUId']['value']
+            except (KeyError, TypeError):
+                messagebox.showerror("Cannot import Pal", "The Pal data is incomplete.")
+                return
             owneruid = "00000000-0000-0000-0000-000000000000"
-            if pal.GetOwner() != owneruid:
+            if not self.palguidmanager._same_guid(source_owner, owneruid):
                 owneruid = playerguid
-            
-            pal.InitializationPal(newguid, playerguid, groupguid, slotguid, owneruid)
-            pal.SetSoltIndex(i)
-            self.palguidmanager.AddGroupSaveData(groupguid, newguid)
-            self.palguidmanager.SetContainerSave(slotguid, i, newguid)
-            self.data['properties']['worldSaveData']['value']['CharacterSaveParameterMap']['value'].append(pal._data)
-            print(f"Add Pal at slot {i} : {slotguid}")
-        self.loaddata(self.data)  # ['properties']['worldSaveData']['value']['CharacterSaveParameterMap']['value'])
+            owner_uids.append(owneruid)
+        inserted = self.palguidmanager.InsertPals(
+            pals, playerguid, groupguid, slotguid, owner_uids)
+        if inserted is None:
+            messagebox.showerror(
+                "Cannot import Pal",
+                "The batch does not fit or its world references are inconsistent. Nothing was imported.")
+            return
+        self.loaddata(self.data)
+        self._select_palbox_instance(inserted[-1]['key']['InstanceId']['value'])
 
     def dumppals(self):
         if not self.isPalSelected():
@@ -2163,11 +2298,7 @@ Do you want to use %s's DEFAULT Scaling (%s)?
         if getattr(self, 'storage_mode', False):
             self.addpal_storage()
         else:
-            messagebox.showinfo(
-                "Global Palbox only",
-                "Adding a brand-new pal is currently supported for the Global "
-                "Palbox (GlobalPalStorage.sav). For world saves, use Add Pal "
-                "to import a dumped pal.")
+            self.spawnpal()
 
     def clonepal(self):
         if getattr(self, 'storage_mode', False):
@@ -2178,51 +2309,28 @@ Do you want to use %s's DEFAULT Scaling (%s)?
             return
         i = int(self.listdisplay.curselection()[0])
         pal = self.FilteredPals()[i]
-
-        owneruid = "00000000-0000-0000-0000-000000000000"
-
-
-        with open("temp.json", "wb") as f:
-            print(f"Data {pal._data}")
-            f.write(json.dumps(pal._data, indent=4, cls=UUIDEncoder).encode('utf-8'))
-
-        f = open("temp.json", "r", encoding="utf8")
-        spawnpaldata = json.loads(f.read())
-        f.close()
-
-        playerguid = self.players[self.current.get()].GetPlayerGuid()
-        playersav = os.path.dirname(self.filename) + f"/Players/{str(playerguid).upper().replace('-', '')}.sav"
-        if not os.path.exists(playersav):
-            print("Cannot Load Player Save!")
-            return
-        player = PalInfo.PalPlayerEntity(palworld_pal_edit.SaveConverter.convert_sav_to_obj(playersav))
-        palworld_pal_edit.SaveConverter.convert_obj_to_sav(player.dump(), playersav + ".bak", True)
-
-        slotguid = str(player.GetPalStorageGuid())
+        player = self.players[self.current.get()]
+        playerguid = player.GetPlayerGuid()
+        slotguid = player.GetPalStorageGuid()
         groupguid = self.palguidmanager.GetGroupGuid(playerguid)
-        if any(guid == None for guid in [slotguid, groupguid]):
+        if any(guid is None for guid in [playerguid, slotguid, groupguid]):
+            messagebox.showerror(
+                "Cannot clone Pal",
+                "The selected player's Players/*.sav file or guild/container data is missing.")
             return
 
-        newguid = str(uuid.uuid4())
-        pal = PalInfo.PalEntity(spawnpaldata)
-        i = self.palguidmanager.GetEmptySlotIndex(slotguid)
-        if i == -1:
-            print("Player Pal Storage is full!")
-            return
-        print(playerguid)
-
-        if pal.GetOwner() != owneruid:
+        owneruid = self.ZERO_GUID
+        if not self.palguidmanager._same_guid(pal.GetOwner(), owneruid):
             owneruid = playerguid
-        
-        pal.InitializationPal(newguid, playerguid, groupguid, slotguid, owneruid)
-        pal.SetSoltIndex(i)
-        self.palguidmanager.AddGroupSaveData(groupguid, newguid)
-        self.palguidmanager.SetContainerSave(slotguid, i, newguid)
-        self.data['properties']['worldSaveData']['value']['CharacterSaveParameterMap']['value'].append(pal._data)
-        print(f"Add Pal at slot {i} : {slotguid}")
+        inserted = self.palguidmanager.InsertPal(
+            pal._data, playerguid, groupguid, slotguid, owneruid)
+        if inserted is None:
+            messagebox.showerror(
+                "Cannot clone Pal",
+                "The player Palbox is full or the world references are inconsistent.")
+            return
         self.loaddata(self.data)
-
-        os.remove("temp.json")
+        self._select_palbox_instance(inserted['key']['InstanceId']['value'])
 
     def deletepal(self):
         if getattr(self, 'storage_mode', False):
@@ -2233,28 +2341,18 @@ Do you want to use %s's DEFAULT Scaling (%s)?
             return
         i = int(self.listdisplay.curselection()[0])
         pal = self.FilteredPals()[i]
-
-        s = pal.GetSlotIndex()
-
-        playerguid = self.players[self.current.get()].GetPlayerGuid()
-        playersav = os.path.dirname(self.filename) + f"/Players/{str(playerguid).upper().replace('-', '')}.sav"
-        if not os.path.exists(playersav):
-            print("Cannot Load Player Save!")
+        if not messagebox.askyesno(
+                "Delete Pal",
+                f"Remove {pal.GetFullName()} from this world save?\n\n"
+                "Its character, container, and guild references will be removed together."):
             return
-        player = PalInfo.PalPlayerEntity(palworld_pal_edit.SaveConverter.convert_sav_to_obj(playersav))
-        palworld_pal_edit.SaveConverter.convert_obj_to_sav(player.dump(), playersav + ".bak", True)
-
-        slotguid = str(player.GetPalStorageGuid())
-        palguid = pal.GetPalInstanceGuid()
-
-        groupguid = self.palguidmanager.GetGroupGuid(playerguid)
-        if any(guid == None for guid in [slotguid, groupguid]):
+        acting_player_guid = self.players[self.current.get()].GetPlayerGuid()
+        if not self.palguidmanager.DeletePalEntry(
+                pal._data, acting_player_guid):
+            messagebox.showerror(
+                "Cannot delete Pal",
+                "The Pal's world references are inconsistent, so nothing was removed.")
             return
-
-        self.palguidmanager.RemovePal(slotguid, s, "0")
-        self.palguidmanager.RemoveGroupSaveData(groupguid, palguid)
-        self.data['properties']['worldSaveData']['value']['CharacterSaveParameterMap']['value'].remove(pal._data)
-        
         self.loaddata(self.data)
 
         
@@ -2572,6 +2670,7 @@ Do you want to use %s's DEFAULT Scaling (%s)?
         self.debug = "false"
         self.editindex = -1
         self.filename = ""
+        self.loaded_file_digest = None
         # save paths already backed up this session (one backup per file)
         self._session_backups = set()
         self.gui = self.createWindow()

--- a/palworld_pal_edit/PalInfo.py
+++ b/palworld_pal_edit/PalInfo.py
@@ -214,7 +214,10 @@ class PalEntity:
 
         # Palworld 1.0 writes IsPlayer=False on every pal, so key presence
         # alone no longer identifies a player character
-        if "IsPlayer" in self._obj and self._obj["IsPlayer"].get("value", False):
+        if (
+                "IsPlayer" in self._obj
+                and self._obj["IsPlayer"].get("value") is not False
+        ):
             raise Exception("This is a player character")
 
         if not "IsRarePal" in self._obj:
@@ -866,15 +869,17 @@ class PalEntity:
 class PalGuid:
     def __init__(self, data):
         self._data = data
+        self._CharacterSaveParameterMap = \
+            data['properties']['worldSaveData']['value']['CharacterSaveParameterMap']['value']
         self._CharacterContainerSaveData = \
             data['properties']['worldSaveData']['value']['CharacterContainerSaveData']['value']
         self._GroupSaveDataMap = data['properties']['worldSaveData']['value']['GroupSaveDataMap']['value']
 
     def GetPlayerslist(self):
-        players = list(filter(lambda x: 'IsPlayer' in x['value'], [
+        players = list(filter(lambda x: x['value'].get('IsPlayer', {}).get('value') is True, [
             {'uid': x['key']['PlayerUId'],
              'value': x['value']['RawData']['value']['object']['SaveParameter']['value']
-             } for x in self._data['properties']['worldSaveData']['value']['CharacterSaveParameterMap']['value']]))
+             } for x in self._CharacterSaveParameterMap]))
 
         out = {}
         for x in players:
@@ -903,77 +908,452 @@ class PalGuid:
         result_list[12] = 1
         return result_list
 
-    def SetContainerSave(self, SoltGuid: str, SlotIndex: int, PalGuid: str):
-        if any(guid == "00000000-0000-0000-0000-000000000000" for guid in [SoltGuid, PalGuid]):
-            return
-        
-        for e in self._CharacterContainerSaveData:
-            if (e['key']['ID']['value'] == SoltGuid):
-                v = len(e['value']['Slots']['value']['values'])-1
+    ZERO_GUID = "00000000-0000-0000-0000-000000000000"
 
-                n = copy.deepcopy(e['value']['Slots']['value']['values'][v])
-                e['value']['Slots']['value']['values'].append(n)
-                e['value']['Slots']['value']['values'][v+1]['SlotIndex']['value'] = SlotIndex
-                e['value']['Slots']['value']['values'][v+1]['RawData']['value']['instance_id'] = PalGuid
-                print(e['value']['Slots']['value']['values'][v+1])
+    @staticmethod
+    def _same_guid(left, right):
+        return str(left).lower() == str(right).lower()
+
+    @staticmethod
+    def _is_unambiguously_non_player(save_parameter):
+        if not isinstance(save_parameter, dict):
+            return False
+        if 'IsPlayer' not in save_parameter:
+            return True
+        marker = save_parameter['IsPlayer']
+        return isinstance(marker, dict) and marker.get('value') is False
+
+    @staticmethod
+    def _validated_group_handles(group):
+        try:
+            handles = group['value']['RawData']['value'][
+                'individual_character_handle_ids']
+        except (KeyError, TypeError):
+            return None
+        if not isinstance(handles, list):
+            return None
+        for handle in handles:
+            if (
+                    not isinstance(handle, dict)
+                    or not ({'guid', 'instance_id'} & handle.keys())
+            ):
+                return None
+        return handles
+
+    def _pal_guid_in_use(self, pal_guid):
+        try:
+            if any(
+                    self._same_guid(
+                        entry['key']['InstanceId']['value'], pal_guid)
+                    for entry in self._CharacterSaveParameterMap
+            ):
+                return True
+            for container in self._CharacterContainerSaveData:
+                for slot in container['value']['Slots']['value']['values']:
+                    if self._same_guid(
+                            slot['RawData']['value']['instance_id'], pal_guid):
+                        return True
+            for group in self._GroupSaveDataMap:
+                handles = self._validated_group_handles(group)
+                if handles is None:
+                    return True
+                if any(self._handle_matches_pal(handle, pal_guid)
+                       for handle in handles):
+                    return True
+        except (KeyError, TypeError):
+            return True
+        return False
+
+    def _find_container(self, slot_guid):
+        matches = [
+            entry for entry in self._CharacterContainerSaveData
+            if self._same_guid(entry['key']['ID']['value'], slot_guid)
+        ]
+        return matches[0] if len(matches) == 1 else None
+
+    def _find_group(self, group_guid):
+        matches = [
+            entry for entry in self._GroupSaveDataMap
+            if self._same_guid(entry['key'], group_guid)
+        ]
+        return matches[0] if len(matches) == 1 else None
+
+    def _slot_template(self, container):
+        slots = container['value']['Slots']['value']['values']
+        if slots:
+            return slots[0]
+        for entry in self._CharacterContainerSaveData:
+            other_slots = entry['value']['Slots']['value']['values']
+            if other_slots:
+                return other_slots[0]
+        return None
+
+    @staticmethod
+    def _container_capacity(container):
+        """Return (capacity, occupied indexes) only for a structurally valid container."""
+        try:
+            slot_num = container['value']['SlotNum']['value']
+            slots = container['value']['Slots']['value']['values']
+            indexes = [slot['SlotIndex']['value'] for slot in slots]
+        except (KeyError, TypeError):
+            return None
+        if (
+                not isinstance(slot_num, int)
+                or slot_num < 0
+                or len(slots) > slot_num
+                or len(set(indexes)) != len(indexes)
+                or any(not isinstance(index, int) or index < 0 or index >= slot_num
+                       for index in indexes)
+        ):
+            return None
+        return slot_num, set(indexes)
+
+    def GetContainerSlot(self, slot_guid, pal_guid):
+        container = self._find_container(slot_guid)
+        if container is None:
+            return None
+        for slot in container['value']['Slots']['value']['values']:
+            instance_id = slot['RawData']['value']['instance_id']
+            if self._same_guid(instance_id, pal_guid):
+                return slot
+        return None
+
+    def SetContainerSave(self, SoltGuid: str, SlotIndex: int, PalGuid: str):
+        if any(self._same_guid(guid, self.ZERO_GUID) for guid in [SoltGuid, PalGuid]):
+            return False
+        container = self._find_container(SoltGuid)
+        if container is None:
+            return False
+        capacity = self._container_capacity(container)
+        if capacity is None:
+            return False
+        slot_num, occupied = capacity
+        slots = container['value']['Slots']['value']['values']
+        if SlotIndex < 0 or SlotIndex >= slot_num:
+            return False
+        if SlotIndex in occupied:
+            return False
+        if self.GetContainerSlot(SoltGuid, PalGuid) is not None:
+            return False
+        template = self._slot_template(container)
+        if template is None:
+            return False
+        slot = copy.deepcopy(template)
+        slot['SlotIndex']['value'] = SlotIndex
+        slot['RawData']['value']['player_uid'] = self.ZERO_GUID
+        slot['RawData']['value']['instance_id'] = PalGuid
+        slots.append(slot)
+        return True
 
     def RemovePal(self, SoltGuid: str, SlotIndex: int, PalGuid: str):
-        if any(guid == "00000000-0000-0000-0000-000000000000" for guid in [SoltGuid, PalGuid]):
-            return
-
-        for e in self._CharacterContainerSaveData:
-            if (e['key']['ID']['value'] == SoltGuid):
-                for p in e['value']['Slots']['value']['values']:
-                    if p['SlotIndex']['value'] == SlotIndex:
-                        e['value']['Slots']['value']['values'].remove(p)
-                        break
+        if any(self._same_guid(guid, self.ZERO_GUID) for guid in [SoltGuid, PalGuid]):
+            return False
+        container = self._find_container(SoltGuid)
+        if container is None:
+            return False
+        slots = container['value']['Slots']['value']['values']
+        for index, slot in enumerate(slots):
+            if (
+                    slot['SlotIndex']['value'] == SlotIndex
+                    and self._same_guid(slot['RawData']['value']['instance_id'], PalGuid)
+            ):
+                slots.pop(index)
+                return True
+        return False
         
 
     def AddGroupSaveData(self, GroupGuid: str, PalGuid: str):
-        if any(guid == "00000000-0000-0000-0000-000000000000" for guid in [GroupGuid, PalGuid]):
-            return
-        for e in self._GroupSaveDataMap:
-            if (e['key'] == GroupGuid):
-                for ee in e['value']['RawData']['value']['individual_character_handle_ids']:
-                    if (ee['instance_id'] == PalGuid):
-                        return
-                tmp = {"guid": "00000000-0000-0000-0000-000000000001", "instance_id": PalGuid}
-                e['value']['RawData']['value']['individual_character_handle_ids'].append(tmp)
+        if any(self._same_guid(guid, self.ZERO_GUID) for guid in [GroupGuid, PalGuid]):
+            return False
+        group = self._find_group(GroupGuid)
+        handles = self._validated_group_handles(group) if group is not None else None
+        if (
+                handles is None
+                or self.GroupContainsPal(GroupGuid, PalGuid)
+        ):
+            return False
+        handles.append({"guid": self.ZERO_GUID, "instance_id": PalGuid})
+        return True
+
+    def _handle_matches_pal(self, handle, pal_guid):
+        guid = handle.get('guid', self.ZERO_GUID)
+        instance_id = handle.get('instance_id', self.ZERO_GUID)
+        return (
+            self._same_guid(guid, self.ZERO_GUID)
+            and self._same_guid(instance_id, pal_guid)
+        ) or (
+            self._same_guid(instance_id, self.ZERO_GUID)
+            and self._same_guid(guid, pal_guid)
+        )
+
+    def GroupContainsPal(self, GroupGuid: str, PalGuid: str):
+        group = self._find_group(GroupGuid)
+        handles = self._validated_group_handles(group) if group is not None else None
+        if handles is None:
+            return False
+        return any(self._handle_matches_pal(handle, PalGuid) for handle in handles)
 
     def RemoveGroupSaveData(self, GroupGuid: str, PalGuid: str):
-        if any(guid == "00000000-0000-0000-0000-000000000000" for guid in [GroupGuid, PalGuid]):
-            return
-        for e in self._GroupSaveDataMap:
-            if (e['key'] == GroupGuid):
-                for ee in e['value']['RawData']['value']['individual_character_handle_ids']:
-                    if (ee['instance_id'] == PalGuid):
-                        e['value']['RawData']['value']['individual_character_handle_ids'].remove(ee)
+        if any(self._same_guid(guid, self.ZERO_GUID) for guid in [GroupGuid, PalGuid]):
+            return False
+        group = self._find_group(GroupGuid)
+        handles = self._validated_group_handles(group) if group is not None else None
+        if handles is None:
+            return False
+        for index, handle in enumerate(handles):
+            if self._handle_matches_pal(handle, PalGuid):
+                handles.pop(index)
+                return True
+        return False
 
     def GetSoltMaxCount(self, SoltGuid: str):
-        if SoltGuid == "00000000-0000-0000-0000-000000000000":
+        if self._same_guid(SoltGuid, self.ZERO_GUID):
             return 0
-        for e in self._CharacterContainerSaveData:
-            if (e['key']['ID']['value'] == SoltGuid):
-                return len(e['value']['Slots']['value']['values'])
+        container = self._find_container(SoltGuid)
+        if container is not None:
+            return container['value']['SlotNum']['value']
+        return 0
 
     def GetEmptySlotIndex(self, SoltGuid: str):
-        print(SoltGuid)
-        if SoltGuid == "00000000-0000-0000-0000-000000000000":
+        if self._same_guid(SoltGuid, self.ZERO_GUID):
             return -1
-        for e in self._CharacterContainerSaveData:
-            if (e['key']['ID']['value'] == SoltGuid):
-                print("Matched", SoltGuid)
-                oc = []
-                Solt = e['value']['Slots']['value']['values']
-                for i in range(len(Solt)):
-                    oc.append(Solt[i]['SlotIndex']['value'])
-                    #if Solt[i]['RawData']['value']['instance_id'] == "00000000-0000-0000-0000-000000000000":
-                       # return i
-                print(oc)
-                for i in range(0, 960):
-                    if i not in oc:
-                        return i
+        container = self._find_container(SoltGuid)
+        if container is not None:
+            capacity = self._container_capacity(container)
+            if capacity is None:
+                return -1
+            slot_num, occupied = capacity
+            for index in range(slot_num):
+                if index not in occupied:
+                    return index
         return -1
+
+    @staticmethod
+    def _pal_entry_fields(entry):
+        raw_data = entry['value']['RawData']['value']
+        save_parameter = raw_data['object']['SaveParameter']['value']
+        return raw_data, save_parameter
+
+    def InsertPal(self, source, player_guid, group_guid, slot_guid, owner_uid,
+                  new_guid=None):
+        """Insert a copied pal and all world references as one checked operation."""
+        if any(value is None for value in [source, player_guid, group_guid, slot_guid]):
+            return None
+        try:
+            source_player_uid = source['key']['PlayerUId']['value']
+        except (KeyError, TypeError):
+            return None
+        if (
+                not self._same_guid(source_player_uid, self.ZERO_GUID)
+                or not self._same_guid(owner_uid, self.ZERO_GUID)
+        ):
+            return None
+        if self._find_container(slot_guid) is None or self._find_group(group_guid) is None:
+            return None
+        slot_index = self.GetEmptySlotIndex(slot_guid)
+        if slot_index < 0:
+            return None
+        new_guid = str(new_guid or uuid.uuid4())
+        if self._pal_guid_in_use(new_guid):
+            return None
+
+        inserted = copy.deepcopy(source)
+        try:
+            raw_data, save_parameter = self._pal_entry_fields(inserted)
+            if not self._is_unambiguously_non_player(save_parameter):
+                return None
+            inserted['key']['PlayerUId']['value'] = self.ZERO_GUID
+            inserted['key']['InstanceId']['value'] = new_guid
+            save_parameter['OwnerPlayerUId']['value'] = player_guid
+            save_parameter['OldOwnerPlayerUIds']['value']['values'] = [player_guid]
+            raw_data['group_id'] = group_guid
+            slot_id = save_parameter['SlotId']['value']
+            slot_id['ContainerId']['value']['ID']['value'] = slot_guid
+            slot_id['SlotIndex']['value'] = slot_index
+        except (KeyError, TypeError):
+            return None
+
+        container = self._find_container(slot_guid)
+        group = self._find_group(group_guid)
+        slots = container['value']['Slots']['value']['values']
+        handles = group['value']['RawData']['value'][
+            'individual_character_handle_ids']
+        character_count = len(self._CharacterSaveParameterMap)
+        slot_count = len(slots)
+        handle_count = len(handles)
+        try:
+            if not self.SetContainerSave(slot_guid, slot_index, new_guid):
+                raise ValueError("Container insertion failed after preflight.")
+            if not self.AddGroupSaveData(group_guid, new_guid):
+                raise ValueError("Guild insertion failed after preflight.")
+            self._CharacterSaveParameterMap.append(inserted)
+        except Exception:
+            del self._CharacterSaveParameterMap[character_count:]
+            del slots[slot_count:]
+            del handles[handle_count:]
+            return None
+        return inserted
+
+    def InsertPals(self, sources, player_guid, group_guid, slot_guid, owner_uids,
+                   new_guids=None):
+        """Insert a batch only when every source can be placed safely."""
+        sources = list(sources)
+        owner_uids = list(owner_uids)
+        if not sources or len(sources) != len(owner_uids):
+            return None
+        if any(not self._same_guid(owner_uid, self.ZERO_GUID)
+               for owner_uid in owner_uids):
+            return None
+        container = self._find_container(slot_guid)
+        if container is None or self._find_group(group_guid) is None:
+            return None
+        capacity = self._container_capacity(container)
+        if capacity is None:
+            return None
+        slot_num, occupied = capacity
+        if slot_num - len(occupied) < len(sources) or self._slot_template(container) is None:
+            return None
+
+        if new_guids is None:
+            new_guids = [str(uuid.uuid4()) for _ in sources]
+        else:
+            new_guids = [str(value) for value in new_guids]
+        if len(new_guids) != len(sources) or len(set(new_guids)) != len(new_guids):
+            return None
+        if any(self._pal_guid_in_use(value) for value in new_guids):
+            return None
+
+        for source in sources:
+            try:
+                _, save_parameter = self._pal_entry_fields(copy.deepcopy(source))
+                if (
+                        not self._same_guid(
+                            source['key']['PlayerUId']['value'], self.ZERO_GUID)
+                        or not self._is_unambiguously_non_player(save_parameter)
+                ):
+                    return None
+                save_parameter['OwnerPlayerUId']['value']
+                save_parameter['OldOwnerPlayerUIds']['value']['values']
+                save_parameter['SlotId']['value']['ContainerId']['value']['ID']['value']
+                save_parameter['SlotId']['value']['SlotIndex']['value']
+            except (KeyError, TypeError):
+                return None
+
+        slots = container['value']['Slots']['value']['values']
+        group = self._find_group(group_guid)
+        handles = group['value']['RawData']['value'][
+            'individual_character_handle_ids']
+        character_count = len(self._CharacterSaveParameterMap)
+        slot_count = len(slots)
+        handle_count = len(handles)
+        inserted = []
+        try:
+            for source, owner_uid, new_guid in zip(sources, owner_uids, new_guids):
+                entry = self.InsertPal(
+                    source, player_guid, group_guid, slot_guid, owner_uid, new_guid)
+                if entry is None:
+                    raise ValueError("Pal insertion failed after preflight.")
+                inserted.append(entry)
+        except Exception:
+            del self._CharacterSaveParameterMap[character_count:]
+            del slots[slot_count:]
+            del handles[handle_count:]
+            return None
+        return inserted
+
+    def DeletePalEntry(self, entry, acting_player_guid):
+        """Delete a pal only when its character and container references agree."""
+        if entry not in self._CharacterSaveParameterMap or acting_player_guid is None:
+            return False
+        try:
+            raw_data, save_parameter = self._pal_entry_fields(entry)
+            if (
+                    not self._same_guid(
+                        entry['key']['PlayerUId']['value'], self.ZERO_GUID)
+                    or not self._is_unambiguously_non_player(save_parameter)
+                    or not self._same_guid(
+                        save_parameter['OwnerPlayerUId']['value'],
+                        acting_player_guid)
+            ):
+                return False
+            pal_guid = entry['key']['InstanceId']['value']
+            group_guid = raw_data['group_id']
+            slot_id = save_parameter['SlotId']['value']
+            slot_guid = slot_id['ContainerId']['value']['ID']['value']
+            slot_index = slot_id['SlotIndex']['value']
+        except (KeyError, TypeError):
+            return False
+        matching_entries = sum(
+            self._same_guid(
+                candidate['key']['InstanceId']['value'], pal_guid)
+            for candidate in self._CharacterSaveParameterMap
+        )
+        if matching_entries != 1:
+            return False
+        container = self._find_container(slot_guid)
+        if container is None:
+            return False
+        matching_slots = []
+        try:
+            for candidate_container in self._CharacterContainerSaveData:
+                for candidate_slot in candidate_container[
+                        'value']['Slots']['value']['values']:
+                    if self._same_guid(
+                            candidate_slot['RawData']['value']['instance_id'],
+                            pal_guid):
+                        matching_slots.append((candidate_container, candidate_slot))
+        except (KeyError, TypeError):
+            return False
+        if len(matching_slots) != 1:
+            return False
+        matched_container, slot = matching_slots[0]
+        if (
+                matched_container is not container
+                or slot['SlotIndex']['value'] != slot_index
+        ):
+            return False
+        group = self._find_group(group_guid)
+        if group is None:
+            return False
+        matching_handles = []
+        for candidate_group in self._GroupSaveDataMap:
+            handles = self._validated_group_handles(candidate_group)
+            if handles is None:
+                return False
+            for handle in handles:
+                if self._handle_matches_pal(handle, pal_guid):
+                    matching_handles.append(candidate_group['key'])
+        if (
+                len(matching_handles) != 1
+                or not self._same_guid(matching_handles[0], group_guid)
+        ):
+            return False
+
+        slots = container['value']['Slots']['value']['values']
+        handles = group['value']['RawData']['value'][
+            'individual_character_handle_ids']
+        handle = next(
+            candidate for candidate in handles
+            if self._handle_matches_pal(candidate, pal_guid))
+        character_index = self._CharacterSaveParameterMap.index(entry)
+        slot_position = slots.index(slot)
+        handle_position = handles.index(handle)
+        try:
+            if not self.RemovePal(slot_guid, slot_index, pal_guid):
+                raise ValueError("Container removal failed after preflight.")
+            if not self.RemoveGroupSaveData(group_guid, pal_guid):
+                raise ValueError("Guild removal failed after preflight.")
+            self._CharacterSaveParameterMap.remove(entry)
+        except Exception:
+            if not any(candidate is entry
+                       for candidate in self._CharacterSaveParameterMap):
+                self._CharacterSaveParameterMap.insert(character_index, entry)
+            if not any(candidate is slot for candidate in slots):
+                slots.insert(slot_position, slot)
+            if not any(candidate is handle for candidate in handles):
+                handles.insert(handle_position, handle)
+            return False
+        return True
 
     def GetAdminGuid(self):
         for e in self._GroupSaveDataMap:
@@ -986,11 +1366,13 @@ class PalGuid:
                 return e['key']
 
     def GetGroupGuid(self, playerguid):        
+        matches = []
         for e in self._GroupSaveDataMap:
             if "players" in e['value']['RawData']['value']:
                 for player in e['value']['RawData']['value']['players']:
                     if player['player_uid'] == playerguid:
-                        return e['key']
+                        matches.append(e['key'])
+        return matches[0] if len(matches) == 1 else None
 
     def RemanePlayer(self, PlayerGuid: str, NewName: str):
         for e in self._GroupSaveDataMap:

--- a/palworld_pal_edit/SaveConverter.py
+++ b/palworld_pal_edit/SaveConverter.py
@@ -65,11 +65,14 @@ def main():
             output_path = args.output
         convert_json_to_sav(args.filename, output_path, args.force)
 
-def convert_sav_to_obj(filename):
+def convert_sav_to_obj(filename, max_input_bytes=None, max_output_size=None):
     print(f"Decompressing sav file")
     with open(filename, "rb") as f:
-        data = f.read()
-        raw_gvas, _ = decompress_sav_to_gvas(data)
+        data = f.read() if max_input_bytes is None else f.read(max_input_bytes + 1)
+        if max_input_bytes is not None and len(data) > max_input_bytes:
+            raise ValueError("The player save file is too large.")
+        raw_gvas, _ = decompress_sav_to_gvas(
+            data, max_output_size=max_output_size)
     print(f"Loading GVAS file")
     gvas_file = GvasFile.read(raw_gvas, PALWORLD_TYPE_HINTS, PALWORLD_CUSTOM_PROPERTIES)
     return gvas_file.dump()

--- a/palworld_save_tools/compressor/oozlib.py
+++ b/palworld_save_tools/compressor/oozlib.py
@@ -123,23 +123,25 @@ class OozLib(Compressor):
 
         return sav_data
 
-    def decompress(self, data: bytes) -> bytes:
+    def decompress(self, data: bytes, max_output_size=None) -> bytes:
         logger.info("Starting decompression process with libooz...")
 
         if not data:
             raise ValueError("SAV data cannot be empty")
 
         format_result = self.check_sav_format(data)
-        if format_result == 0:
-            raise ValueError(
-                "Detected PLZ format (Zlib), this tool only supports PLM format (Oodle)"
-            )
-        elif format_result == -1:
-            raise ValueError("Unknown SAV file format")
+        if format_result != SaveType.PLM:
+            raise ValueError("This decoder requires the Oodle PLM save format")
 
         uncompressed_len, compressed_len, magic, save_type, data_offset = (
             self._parse_sav_header(data)
         )
+        if save_type != SaveType.PLM.value:
+            raise ValueError("Oodle save header has an invalid save type")
+        if len(data) != data_offset + compressed_len:
+            raise ValueError("Oodle save payload length does not match its header")
+        if max_output_size is not None and uncompressed_len > max_output_size:
+            raise ValueError("SAV decompressed output exceeds the configured limit")
 
         logger.debug("File information (Decompress):")
         logger.debug(f"  Magic bytes: {magic.decode('ascii', errors='ignore')}")

--- a/palworld_save_tools/compressor/zlib.py
+++ b/palworld_save_tools/compressor/zlib.py
@@ -41,7 +41,20 @@ class Zlib(Compressor):
 
         return sav_data
 
-    def decompress(self, data: bytes) -> bytes:
+    @staticmethod
+    def _decompress_bounded(data: bytes, maximum: int) -> bytes:
+        decoder = zlib.decompressobj()
+        output = decoder.decompress(data, maximum + 1)
+        if len(output) > maximum or decoder.unconsumed_tail:
+            raise ValueError("SAV decompressed output exceeds the configured limit")
+        output += decoder.flush()
+        if len(output) > maximum:
+            raise ValueError("SAV decompressed output exceeds the configured limit")
+        if not decoder.eof or decoder.unused_data:
+            raise ValueError("Invalid or trailing zlib payload")
+        return output
+
+    def decompress(self, data: bytes, max_output_size=None) -> bytes:
         logger.info("Starting decompression process with zlib...")
 
         format_result = self.check_sav_format(data)
@@ -57,6 +70,13 @@ class Zlib(Compressor):
         uncompressed_len, compressed_len, magic, save_type, data_offset = (
             self._parse_sav_header(data)
         )
+        if save_type != SaveType.PLZ.value:
+            raise ValueError("Zlib save header has an invalid save type")
+        if max_output_size is not None and uncompressed_len > max_output_size:
+            raise ValueError("SAV decompressed output exceeds the configured limit")
+        if (max_output_size is not None
+                and compressed_len > max(max_output_size, len(data))):
+            raise ValueError("SAV intermediate output exceeds the configured limit")
 
         logger.debug("File information (Decompress):")
         logger.debug(f"  Magic bytes: {magic.decode('ascii', errors='ignore')}")
@@ -65,13 +85,17 @@ class Zlib(Compressor):
         logger.debug(f"  Uncompressed size: {uncompressed_len:,} bytes")
         logger.debug("Detected PLZ format (Zlib), starting decompression...")
 
-        uncompressed_data = zlib.decompress(data[data_offset:])
+        outer_limit = compressed_len
+        uncompressed_data = self._decompress_bounded(
+            data[data_offset:], outer_limit)
 
         if save_type == SaveType.PLZ.value:
             if compressed_len != len(uncompressed_data):
                 raise Exception(f"incorrect compressed length: {compressed_len}")
 
-            uncompressed_data = zlib.decompress(uncompressed_data)
+            inner_limit = max_output_size if max_output_size is not None else uncompressed_len
+            uncompressed_data = self._decompress_bounded(
+                uncompressed_data, inner_limit)
 
         if uncompressed_len != len(uncompressed_data):
             raise Exception(

--- a/palworld_save_tools/palsav.py
+++ b/palworld_save_tools/palsav.py
@@ -27,7 +27,9 @@ def configure_logging(debug: bool = False):
         )
 
 
-def decompress_sav_to_gvas(data: bytes, debug: bool = False) -> tuple[bytes, int]:
+def decompress_sav_to_gvas(
+        data: bytes, debug: bool = False, max_output_size=None
+) -> tuple[bytes, int]:
     configure_logging(debug)
     format = compressor.check_sav_format(data)
 
@@ -36,9 +38,9 @@ def decompress_sav_to_gvas(data: bytes, debug: bool = False) -> tuple[bytes, int
 
     match format:
         case SaveType.PLZ | SaveType.CNK:
-            return z_lib.decompress(data)
+            return z_lib.decompress(data, max_output_size=max_output_size)
         case SaveType.PLM:
-            return oozlib.decompress(data)
+            return oozlib.decompress(data, max_output_size=max_output_size)
         case _:
             raise Exception("Unknown save format")
 

--- a/tests/test_bounded_decompression.py
+++ b/tests/test_bounded_decompression.py
@@ -1,0 +1,102 @@
+import os
+import random
+import tempfile
+import unittest
+
+from palworld_pal_edit.SaveConverter import convert_sav_to_obj
+from palworld_save_tools.palsav import (
+    compress_gvas_to_sav,
+    decompress_sav_to_gvas,
+    oozlib,
+)
+
+
+class BoundedDecompressionTests(unittest.TestCase):
+    def test_zlib_output_at_limit_is_accepted(self):
+        payload = b"x" * 1024
+        save = compress_gvas_to_sav(payload, 0x32)
+
+        decompressed, save_type = decompress_sav_to_gvas(
+            save, max_output_size=len(payload))
+
+        self.assertEqual(decompressed, payload)
+        self.assertEqual(save_type, 0x32)
+
+    def test_incompressible_zlib_output_at_limit_is_accepted(self):
+        payload = random.Random(0).randbytes(1024)
+        save = compress_gvas_to_sav(payload, 0x32)
+
+        decompressed, save_type = decompress_sav_to_gvas(
+            save, max_output_size=len(payload))
+
+        self.assertEqual(decompressed, payload)
+        self.assertEqual(save_type, 0x32)
+
+    def test_zlib_rejects_mismatched_save_types(self):
+        payload = random.Random(2).randbytes(1024)
+        original = compress_gvas_to_sav(payload, 0x32)
+
+        for invalid_type in (0x31, 0x30, 0x7F):
+            with self.subTest(invalid_type=invalid_type):
+                save = bytearray(original)
+                save[11] = invalid_type
+                with self.assertRaisesRegex(ValueError, "type"):
+                    decompress_sav_to_gvas(bytes(save), max_output_size=2048)
+
+    def test_zlib_declared_output_over_limit_is_rejected(self):
+        save = compress_gvas_to_sav(b"x" * 1024, 0x32)
+
+        with self.assertRaisesRegex(ValueError, "decompressed output"):
+            decompress_sav_to_gvas(save, max_output_size=512)
+
+    def test_oodle_declared_output_over_limit_is_rejected_before_decode(self):
+        compressed = b"x" * 64
+        save = oozlib.build_sav(
+            compressed, 1024, len(compressed), oozlib._get_magic(0x31), 0x31)
+
+        with self.assertRaisesRegex(ValueError, "decompressed output"):
+            decompress_sav_to_gvas(save, max_output_size=512)
+
+    def test_oodle_rejects_mismatched_save_type(self):
+        payload = random.Random(1).randbytes(1024)
+        save = bytearray(compress_gvas_to_sav(payload, 0x31))
+        save[11] = 0x32
+
+        with self.assertRaisesRegex(ValueError, "type"):
+            decompress_sav_to_gvas(bytes(save), max_output_size=2048)
+
+    def test_oodle_decoder_rejects_non_oodle_magic(self):
+        payload = random.Random(1).randbytes(1024)
+        save = bytearray(compress_gvas_to_sav(payload, 0x31))
+        save[8:11] = b"PlZ"
+
+        with self.assertRaisesRegex(ValueError, "format"):
+            oozlib.decompress(bytes(save), max_output_size=2048)
+
+    def test_oodle_rejects_trailing_payload(self):
+        payload = random.Random(1).randbytes(1024)
+        save = compress_gvas_to_sav(payload, 0x31) + b"trailer"
+
+        with self.assertRaisesRegex(ValueError, "payload length"):
+            decompress_sav_to_gvas(save, max_output_size=2048)
+
+    def test_oodle_rejects_truncated_payload(self):
+        payload = random.Random(1).randbytes(1024)
+        save = compress_gvas_to_sav(payload, 0x31)[:-1]
+
+        with self.assertRaisesRegex(ValueError, "payload length"):
+            decompress_sav_to_gvas(save, max_output_size=2048)
+
+    def test_player_save_input_is_bounded_before_decompression(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "Player.sav")
+            with open(source, "wb") as source_file:
+                source_file.write(b"123456789")
+
+            with self.assertRaisesRegex(ValueError, "too large"):
+                convert_sav_to_obj(
+                    source, max_input_bytes=8, max_output_size=16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_level_save_support.py
+++ b/tests/test_level_save_support.py
@@ -1,0 +1,767 @@
+import copy
+import unittest
+
+from palworld_pal_edit.PalInfo import PalGuid
+from palworld_pal_edit.PalEdit import PalEdit
+
+
+ZERO_GUID = "00000000-0000-0000-0000-000000000000"
+PLAYER_GUID = "11111111-1111-1111-1111-111111111111"
+GROUP_GUID = "22222222-2222-2222-2222-222222222222"
+CONTAINER_GUID = "33333333-3333-3333-3333-333333333333"
+SOURCE_GUID = "44444444-4444-4444-4444-444444444444"
+NEW_GUID = "55555555-5555-5555-5555-555555555555"
+OTHER_GUID = "66666666-6666-6666-6666-666666666666"
+
+
+class _Value:
+    def __init__(self):
+        self.value = None
+
+    def set(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class _PlayerDrop:
+    def __init__(self):
+        self.values = None
+        self.state = None
+        self.index = None
+
+    def __setitem__(self, key, value):
+        if key == "values":
+            self.values = value
+
+    def config(self, **kwargs):
+        self.state = kwargs.get("state", self.state)
+
+    def current(self, index):
+        self.index = index
+
+
+def pal_entry(instance_id=SOURCE_GUID, player_uid=PLAYER_GUID, slot_index=0,
+              is_player=False, nickname="Pal", key_player_uid=ZERO_GUID):
+    save_parameter = {
+        "NickName": {"value": nickname},
+        "IsPlayer": {"value": is_player},
+        "OwnerPlayerUId": {"value": player_uid},
+        "OldOwnerPlayerUIds": {"value": {"values": [player_uid]}},
+        "SlotId": {
+            "value": {
+                "ContainerId": {"value": {"ID": {"value": CONTAINER_GUID}}},
+                "SlotIndex": {"value": slot_index},
+            }
+        },
+    }
+    return {
+        "key": {
+            "PlayerUId": {"value": player_uid if is_player else key_player_uid},
+            "InstanceId": {"value": instance_id},
+        },
+        "value": {
+            "RawData": {
+                "value": {
+                    "group_id": GROUP_GUID,
+                    "object": {"SaveParameter": {"value": save_parameter}},
+                }
+            }
+        },
+    }
+
+
+def container_slot(slot_index, instance_id):
+    return {
+        "SlotIndex": {"type": "IntProperty", "id": None, "value": slot_index},
+        "RawData": {
+            "type": "ArrayProperty",
+            "array_type": "ByteProperty",
+            "id": None,
+            "value": {
+                "player_uid": ZERO_GUID,
+                "instance_id": instance_id,
+                "permission_tribe_id": 0,
+                "unknown_bytes": b"\x00\x00\x00\x00\x00",
+            },
+        },
+        "CustomVersionData": {
+            "type": "ArrayProperty",
+            "array_type": "ByteProperty",
+            "id": None,
+            "value": {"values": b"version"},
+        },
+    }
+
+
+def world_data(slot_num=3, slots=None, characters=None, handles=None):
+    slots = list(slots or [])
+    characters = list(characters or [])
+    handles = list(handles or [])
+    return {
+        "properties": {
+            "worldSaveData": {
+                "value": {
+                    "CharacterSaveParameterMap": {"value": characters},
+                    "CharacterContainerSaveData": {
+                        "value": [
+                            {
+                                "key": {"ID": {"value": CONTAINER_GUID}},
+                                "value": {
+                                    "SlotNum": {"value": slot_num},
+                                    "Slots": {"value": {"values": slots}},
+                                },
+                            }
+                        ]
+                    },
+                    "GroupSaveDataMap": {
+                        "value": [
+                            {
+                                "key": GROUP_GUID,
+                                "value": {
+                                    "RawData": {
+                                        "value": {
+                                            "admin_player_uid": PLAYER_GUID,
+                                            "players": [
+                                                {"player_uid": PLAYER_GUID}
+                                            ],
+                                            "individual_character_handle_ids": handles,
+                                        }
+                                    }
+                                },
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+    }
+
+
+class LevelSaveOperationsTests(unittest.TestCase):
+    def test_empty_world_disables_player_selection_without_defaulting(self):
+        editor = PalEdit.__new__(PalEdit)
+        editor.players = {}
+        editor.current = _Value()
+        editor.playerdrop = _PlayerDrop()
+
+        selected = editor._configure_player_selection()
+
+        self.assertFalse(selected)
+        self.assertEqual(editor.current.get(), "")
+        self.assertEqual(editor.playerdrop.values, [])
+        self.assertEqual(editor.playerdrop.state, "disabled")
+        self.assertIsNone(editor.playerdrop.index)
+
+    def test_player_list_requires_is_player_to_be_true(self):
+        false_player = pal_entry(is_player=False, nickname="Ordinary Pal")
+        malformed_player = pal_entry(
+            instance_id=NEW_GUID,
+            player_uid=NEW_GUID,
+            is_player=1,
+            nickname="Malformed Player",
+        )
+        true_player = pal_entry(
+            instance_id=OTHER_GUID,
+            player_uid=OTHER_GUID,
+            is_player=True,
+            nickname="Real Player",
+        )
+        manager = PalGuid(world_data(
+            characters=[false_player, malformed_player, true_player]))
+
+        players = manager.GetPlayerslist()
+
+        self.assertEqual(players, {"Real Player": OTHER_GUID})
+
+    def test_insert_pal_refuses_duplicate_target_container_ids(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        containers = data['properties']['worldSaveData']['value'][
+            'CharacterContainerSaveData']['value']
+        containers.append(copy.deepcopy(containers[0]))
+        before = copy.deepcopy(data)
+
+        inserted = PalGuid(data).InsertPal(
+            source, PLAYER_GUID, GROUP_GUID, CONTAINER_GUID, ZERO_GUID,
+            new_guid=NEW_GUID)
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_refuses_duplicate_target_group_ids(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        groups = data['properties']['worldSaveData']['value'][
+            'GroupSaveDataMap']['value']
+        groups.append(copy.deepcopy(groups[0]))
+        before = copy.deepcopy(data)
+
+        inserted = PalGuid(data).InsertPal(
+            source, PLAYER_GUID, GROUP_GUID, CONTAINER_GUID, ZERO_GUID,
+            new_guid=NEW_GUID)
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_refuses_conflicting_guild_handle_identities(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": SOURCE_GUID, "instance_id": OTHER_GUID}],
+        )
+        before = copy.deepcopy(data)
+
+        deleted = PalGuid(data).DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_claims_first_free_slot_and_all_references(self):
+        source = pal_entry()
+        manager = PalGuid(
+            world_data(
+                slots=[container_slot(0, SOURCE_GUID), container_slot(2, OTHER_GUID)],
+                characters=[source],
+                handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+            )
+        )
+
+        inserted = manager.InsertPal(
+            source,
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            ZERO_GUID,
+            new_guid=NEW_GUID,
+        )
+
+        self.assertIsNotNone(inserted)
+        self.assertEqual(inserted["key"]["InstanceId"]["value"], NEW_GUID)
+        save_parameter = inserted["value"]["RawData"]["value"]["object"]["SaveParameter"]["value"]
+        self.assertEqual(save_parameter["SlotId"]["value"]["SlotIndex"]["value"], 1)
+        self.assertEqual(save_parameter["SlotId"]["value"]["ContainerId"]["value"]["ID"]["value"], CONTAINER_GUID)
+        self.assertEqual(manager.GetContainerSlot(CONTAINER_GUID, NEW_GUID)["SlotIndex"]["value"], 1)
+        self.assertTrue(manager.GroupContainsPal(GROUP_GUID, NEW_GUID))
+        self.assertEqual(len(manager._CharacterSaveParameterMap), 2)
+
+    def test_insert_pal_is_failure_atomic_when_container_is_full(self):
+        source = pal_entry()
+        data = world_data(
+            slot_num=1,
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        inserted = manager.InsertPal(
+            source,
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            ZERO_GUID,
+            new_guid=NEW_GUID,
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_refuses_inconsistent_container_at_nominal_capacity(self):
+        source = pal_entry()
+        data = world_data(
+            slot_num=2,
+            slots=[container_slot(0, SOURCE_GUID), container_slot(0, OTHER_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        inserted = manager.InsertPal(
+            source,
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            ZERO_GUID,
+            new_guid=NEW_GUID,
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_refuses_player_character_source(self):
+        source = pal_entry(is_player=True)
+        data = world_data(
+            slots=[container_slot(0, OTHER_GUID)],
+            handles=[{"guid": ZERO_GUID, "instance_id": OTHER_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        inserted = manager.InsertPal(
+            source,
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            ZERO_GUID,
+            new_guid=NEW_GUID,
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_refuses_non_boolean_player_marker(self):
+        source = pal_entry(is_player=1)
+        source['key']['PlayerUId']['value'] = ZERO_GUID
+        data = world_data(
+            slots=[container_slot(0, OTHER_GUID)],
+            handles=[{"guid": ZERO_GUID, "instance_id": OTHER_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        inserted = manager.InsertPal(
+            source,
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            ZERO_GUID,
+            new_guid=NEW_GUID,
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_refuses_explicit_null_player_marker(self):
+        source = pal_entry(is_player=False)
+        source['value']['RawData']['value']['object'][
+            'SaveParameter']['value']['IsPlayer'] = None
+        data = world_data(
+            slots=[container_slot(0, OTHER_GUID)],
+            handles=[{"guid": ZERO_GUID, "instance_id": OTHER_GUID}],
+        )
+        before = copy.deepcopy(data)
+
+        inserted = PalGuid(data).InsertPal(
+            source, PLAYER_GUID, GROUP_GUID, CONTAINER_GUID, ZERO_GUID,
+            new_guid=NEW_GUID)
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_refuses_malformed_existing_guild_handle(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"unexpected": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        inserted = manager.InsertPal(
+            source,
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            ZERO_GUID,
+            new_guid=NEW_GUID,
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_refuses_nonzero_character_map_player_key(self):
+        source = pal_entry(key_player_uid=OTHER_GUID)
+        data = world_data(
+            slots=[container_slot(0, OTHER_GUID)],
+            handles=[{"guid": ZERO_GUID, "instance_id": OTHER_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        inserted = manager.InsertPal(
+            source,
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            ZERO_GUID,
+            new_guid=NEW_GUID,
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_insert_pal_refuses_guid_used_by_another_container(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        containers = data['properties']['worldSaveData']['value'][
+            'CharacterContainerSaveData']['value']
+        other_container = copy.deepcopy(containers[0])
+        other_container['key']['ID']['value'] = (
+            "88888888-8888-8888-8888-888888888888")
+        other_container['value']['Slots']['value']['values'] = [
+            container_slot(0, NEW_GUID)
+        ]
+        containers.append(other_container)
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        inserted = manager.InsertPal(
+            source,
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            ZERO_GUID,
+            new_guid=NEW_GUID,
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_batch_insert_is_failure_atomic_when_all_sources_do_not_fit(self):
+        source = pal_entry()
+        second = pal_entry(instance_id=OTHER_GUID)
+        data = world_data(
+            slot_num=2,
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        inserted = manager.InsertPals(
+            [source, second],
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            [ZERO_GUID, ZERO_GUID],
+            new_guids=[NEW_GUID, "77777777-7777-7777-7777-777777777777"],
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_batch_insert_restores_all_structures_when_later_insert_raises(self):
+        class FailingSecondInsertManager(PalGuid):
+            def __init__(self, data):
+                super().__init__(data)
+                self.calls = 0
+
+            def InsertPal(self, *args, **kwargs):
+                self.calls += 1
+                if self.calls == 2:
+                    raise RuntimeError("injected insertion failure")
+                return super().InsertPal(*args, **kwargs)
+
+        source = pal_entry()
+        second = pal_entry(instance_id=OTHER_GUID)
+        data = world_data(
+            slot_num=3,
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        character_ref = data['properties']['worldSaveData']['value'][
+            'CharacterSaveParameterMap']['value'][0]
+        container_ref = data['properties']['worldSaveData']['value'][
+            'CharacterContainerSaveData']['value'][0]
+        group_ref = data['properties']['worldSaveData']['value'][
+            'GroupSaveDataMap']['value'][0]
+        manager = FailingSecondInsertManager(data)
+
+        inserted = manager.InsertPals(
+            [source, second],
+            PLAYER_GUID,
+            GROUP_GUID,
+            CONTAINER_GUID,
+            [ZERO_GUID, ZERO_GUID],
+            new_guids=[NEW_GUID, "77777777-7777-7777-7777-777777777777"],
+        )
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+        self.assertIs(manager._CharacterSaveParameterMap[0], character_ref)
+        self.assertIs(manager._CharacterContainerSaveData[0], container_ref)
+        self.assertIs(manager._GroupSaveDataMap[0], group_ref)
+
+    def test_single_insert_restores_all_structures_when_group_append_raises(self):
+        class FailingGroupAppendManager(PalGuid):
+            def AddGroupSaveData(self, *args, **kwargs):
+                raise RuntimeError("injected guild append failure")
+
+        source = pal_entry()
+        data = world_data(
+            slot_num=2,
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = FailingGroupAppendManager(data)
+
+        inserted = manager.InsertPal(
+            source, PLAYER_GUID, GROUP_GUID, CONTAINER_GUID, ZERO_GUID,
+            new_guid=NEW_GUID)
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_removes_character_container_and_group_references(self):
+        source = pal_entry()
+        other = pal_entry(instance_id=OTHER_GUID, slot_index=1)
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID), container_slot(1, OTHER_GUID)],
+            characters=[source, other],
+            handles=[
+                {"guid": ZERO_GUID, "instance_id": SOURCE_GUID},
+                {"guid": ZERO_GUID, "instance_id": OTHER_GUID},
+            ],
+        )
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertTrue(deleted)
+        self.assertIsNone(manager.GetContainerSlot(CONTAINER_GUID, SOURCE_GUID))
+        self.assertFalse(manager.GroupContainsPal(GROUP_GUID, SOURCE_GUID))
+        self.assertEqual(manager.GetContainerSlot(CONTAINER_GUID, OTHER_GUID)["SlotIndex"]["value"], 1)
+        self.assertTrue(manager.GroupContainsPal(GROUP_GUID, OTHER_GUID))
+        self.assertEqual(manager._CharacterSaveParameterMap, [other])
+
+    def test_delete_pal_restores_all_structures_when_mutation_raises(self):
+        class FailingRemoveManager(PalGuid):
+            def RemoveGroupSaveData(self, *args, **kwargs):
+                raise RuntimeError("injected removal failure")
+
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        character_ref = data['properties']['worldSaveData']['value'][
+            'CharacterSaveParameterMap']['value'][0]
+        container_ref = data['properties']['worldSaveData']['value'][
+            'CharacterContainerSaveData']['value'][0]
+        group_ref = data['properties']['worldSaveData']['value'][
+            'GroupSaveDataMap']['value'][0]
+        manager = FailingRemoveManager(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+        self.assertIs(manager._CharacterSaveParameterMap[0], character_ref)
+        self.assertIs(manager._CharacterContainerSaveData[0], container_ref)
+        self.assertIs(manager._GroupSaveDataMap[0], group_ref)
+
+    def test_delete_pal_refuses_foreign_owner_without_changes(self):
+        source = pal_entry(player_uid=OTHER_GUID)
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_refuses_nonzero_character_map_player_key(self):
+        source = pal_entry(key_player_uid=OTHER_GUID)
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+
+        deleted = PalGuid(data).DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_refuses_duplicate_cross_container_reference(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        containers = data['properties']['worldSaveData']['value'][
+            'CharacterContainerSaveData']['value']
+        other_container = copy.deepcopy(containers[0])
+        other_container['key']['ID']['value'] = (
+            "88888888-8888-8888-8888-888888888888")
+        containers.append(other_container)
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_removes_guid_form_guild_reference(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": SOURCE_GUID, "instance_id": ZERO_GUID}],
+        )
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertTrue(deleted)
+        self.assertEqual(
+            data['properties']['worldSaveData']['value']['GroupSaveDataMap']
+            ['value'][0]['value']['RawData']['value']
+            ['individual_character_handle_ids'],
+            [],
+        )
+
+    def test_delete_pal_refuses_duplicate_character_entries_without_changes(self):
+        source = pal_entry()
+        duplicate = copy.deepcopy(source)
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source, duplicate],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_refuses_inconsistent_container_reference_without_changes(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, OTHER_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_refuses_duplicate_guild_references_without_changes(self):
+        source = pal_entry()
+        duplicate_handle = {"guid": ZERO_GUID, "instance_id": SOURCE_GUID}
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[copy.deepcopy(duplicate_handle), copy.deepcopy(duplicate_handle)],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_refuses_missing_guild_reference_without_changes(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[],
+        )
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_refuses_guild_reference_in_different_group(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[],
+        )
+        groups = data['properties']['worldSaveData']['value']['GroupSaveDataMap']['value']
+        other_group = copy.deepcopy(groups[0])
+        other_group['key'] = OTHER_GUID
+        other_group['value']['RawData']['value']['individual_character_handle_ids'] = [
+            {"guid": ZERO_GUID, "instance_id": SOURCE_GUID}
+        ]
+        groups.append(other_group)
+        before = copy.deepcopy(data)
+        manager = PalGuid(data)
+
+        deleted = manager.DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+    def test_batch_insert_refuses_non_object_save_parameter(self):
+        source = pal_entry()
+        malformed = pal_entry(instance_id=OTHER_GUID)
+        malformed['value']['RawData']['value']['object'][
+            'SaveParameter']['value'] = "not an object"
+        data = world_data(
+            slot_num=3,
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=[{"guid": ZERO_GUID, "instance_id": SOURCE_GUID}],
+        )
+        before = copy.deepcopy(data)
+
+        inserted = PalGuid(data).InsertPals(
+            [source, malformed], PLAYER_GUID, GROUP_GUID, CONTAINER_GUID,
+            [ZERO_GUID, ZERO_GUID], new_guids=[NEW_GUID, OTHER_GUID])
+
+        self.assertIsNone(inserted)
+        self.assertEqual(data, before)
+
+    def test_delete_pal_refuses_non_object_guild_handle(self):
+        source = pal_entry()
+        data = world_data(
+            slots=[container_slot(0, SOURCE_GUID)],
+            characters=[source],
+            handles=["not an object"],
+        )
+        before = copy.deepcopy(data)
+
+        deleted = PalGuid(data).DeletePalEntry(source, PLAYER_GUID)
+
+        self.assertFalse(deleted)
+        self.assertEqual(data, before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_save_writing.py
+++ b/tests/test_save_writing.py
@@ -1,0 +1,212 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from palworld_pal_edit.PalEdit import (
+    PalEdit,
+    atomic_write_save,
+    file_digest,
+    load_pal_import,
+    read_bounded_file,
+    validate_player_save_identity,
+    serialize_and_validate_save,
+)
+
+
+class _InvalidGvas:
+    def write(self, _custom_properties):
+        return b"not a gvas file"
+
+
+class _SerializedGvas:
+    def __init__(self, payload, trailer=b"\x00\x00\x00\x00"):
+        self.payload = payload
+        self.trailer = trailer
+
+    def write(self, _custom_properties):
+        return self.payload
+
+
+class SaveWritingTests(unittest.TestCase):
+    def test_player_save_identity_must_match_world_player_guid(self):
+        class Player:
+            def GetPlayerGuid(self):
+                return "11111111-1111-1111-1111-111111111111"
+
+        self.assertIs(
+            validate_player_save_identity(
+                Player(), "11111111-1111-1111-1111-111111111111"),
+            None,
+        )
+        with self.assertRaisesRegex(ValueError, "identity"):
+            validate_player_save_identity(
+                Player(), "22222222-2222-2222-2222-222222222222")
+
+    def test_failed_save_parse_clears_previous_session_before_save_can_run(self):
+        class Value:
+            def __init__(self, value):
+                self.value = value
+
+            def set(self, value):
+                self.value = value
+
+        class Widget:
+            def config(self, **_kwargs):
+                pass
+
+        class Gui:
+            def title(self, value):
+                self.value = value
+
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "Level.sav")
+            with open(source, "wb") as source_file:
+                source_file.write(b"candidate save")
+            editor = PalEdit.__new__(PalEdit)
+            editor.skilllabel = Widget()
+            editor.i18n = {
+                'msg_saving': 'saving',
+                'msg_decompressing': 'decompressing',
+                'msg_loading': 'loading',
+            }
+            editor.gui = Gui()
+            editor.current = Value("Old player")
+            editor.filename = "old.sav"
+            editor.loaded_file_digest = b"old digest"
+            editor.save_type = 0x31
+            editor.data = {"old": True}
+            editor.palguidmanager = object()
+            editor.palbox = [object()]
+            editor.players = {"Old player": object()}
+            editor.disable_menus = lambda: None
+            editor.logerror = lambda _message: None
+            editor.loaddata = lambda _gvas: (_ for _ in ()).throw(
+                ValueError("injected load failure"))
+
+            with (
+                    patch("palworld_pal_edit.PalEdit.askopenfilename",
+                          return_value=source),
+                    patch("palworld_pal_edit.PalEdit.decompress_sav_to_gvas",
+                          return_value=(b"raw gvas", 0x32)),
+                    patch("palworld_pal_edit.PalEdit.GvasFile.read",
+                          side_effect=ValueError("injected parse failure")),
+                    patch("palworld_pal_edit.PalEdit.logger", create=True),
+            ):
+                editor.loadfile()
+
+            self.assertEqual(editor.filename, "")
+            self.assertIsNone(editor.loaded_file_digest)
+            self.assertIsNone(editor.save_type)
+            self.assertIsNone(editor.data)
+            self.assertIsNone(editor.palguidmanager)
+            self.assertEqual(editor.palbox, [])
+            self.assertEqual(editor.players, {})
+            self.assertEqual(editor.current.value, "")
+
+    def test_bounded_file_read_accepts_limit_and_rejects_one_byte_over(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "Level.sav")
+            with open(source, "wb") as source_file:
+                source_file.write(b"12345678")
+
+            self.assertEqual(read_bounded_file(source, max_bytes=8), b"12345678")
+            with self.assertRaisesRegex(ValueError, "too large"):
+                read_bounded_file(source, max_bytes=7)
+
+    def test_pal_import_loader_rejects_oversized_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "oversized.json")
+            with open(source, "wb") as source_file:
+                source_file.write(b"x" * 9)
+
+            with self.assertRaisesRegex(ValueError, "too large"):
+                load_pal_import(source, max_bytes=8)
+
+    def test_pal_import_loader_parses_bounded_json(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = os.path.join(directory, "pal.json")
+            with open(source, "wb") as source_file:
+                source_file.write(b'{"Pals": []}')
+
+            self.assertEqual(load_pal_import(source, max_bytes=32), {"Pals": []})
+
+    def test_atomic_write_replaces_target_and_removes_temporary_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = os.path.join(directory, "Level.sav")
+            with open(target, "wb") as save_file:
+                save_file.write(b"old save")
+
+            atomic_write_save(target, b"new save")
+
+            with open(target, "rb") as save_file:
+                self.assertEqual(save_file.read(), b"new save")
+            self.assertFalse(os.path.exists(target + ".PalEdit.tmp"))
+
+    def test_atomic_write_does_not_follow_a_predictable_temporary_hard_link(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = os.path.join(directory, "Level.sav")
+            victim = os.path.join(directory, "unrelated.sav")
+            predictable_temporary = target + ".PalEdit.tmp"
+            with open(target, "wb") as save_file:
+                save_file.write(b"old save")
+            with open(victim, "wb") as victim_file:
+                victim_file.write(b"unrelated data")
+            os.link(victim, predictable_temporary)
+
+            atomic_write_save(target, b"new save")
+
+            with open(target, "rb") as save_file:
+                self.assertEqual(save_file.read(), b"new save")
+            with open(victim, "rb") as victim_file:
+                self.assertEqual(victim_file.read(), b"unrelated data")
+
+    def test_atomic_write_refuses_target_changed_since_save_started(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = os.path.join(directory, "Level.sav")
+            with open(target, "wb") as save_file:
+                save_file.write(b"loaded save")
+            expected_digest = file_digest(target)
+            with open(target, "wb") as external_writer:
+                external_writer.write(b"newer external save")
+
+            with self.assertRaisesRegex(RuntimeError, "changed on disk"):
+                atomic_write_save(
+                    target, b"PalEdit save", expected_digest=expected_digest)
+
+            with open(target, "rb") as save_file:
+                self.assertEqual(save_file.read(), b"newer external save")
+
+
+    def test_serialization_refuses_bytes_that_do_not_reparse_as_gvas(self):
+        with self.assertRaises(Exception):
+            serialize_and_validate_save(_InvalidGvas(), 0x31)
+
+    def test_serialization_refuses_incomplete_reparse(self):
+        with (
+                patch("palworld_pal_edit.PalEdit.compress_gvas_to_sav",
+                      return_value=b"compressed"),
+                patch("palworld_pal_edit.PalEdit.decompress_sav_to_gvas",
+                      return_value=(b"complete gvas", 0x31)),
+                patch("palworld_pal_edit.PalEdit.GvasFile.read",
+                      return_value=_SerializedGvas(b"partial gvas")),
+                self.assertRaisesRegex(ValueError, "reparse"),
+        ):
+            serialize_and_validate_save(_SerializedGvas(b"complete gvas"), 0x31)
+
+    def test_serialization_refuses_nonstandard_gvas_trailer(self):
+        malformed = _SerializedGvas(b"complete gvas", trailer=b"unexpected")
+        with (
+                patch("palworld_pal_edit.PalEdit.compress_gvas_to_sav",
+                      return_value=b"compressed"),
+                patch("palworld_pal_edit.PalEdit.decompress_sav_to_gvas",
+                      return_value=(b"complete gvas", 0x31)),
+                patch("palworld_pal_edit.PalEdit.GvasFile.read",
+                      return_value=malformed),
+                self.assertRaisesRegex(ValueError, "trailer"),
+        ):
+            serialize_and_validate_save(_SerializedGvas(b"complete gvas"), 0x31)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds safe Palworld 1.0 `Level.sav` editing while preserving the existing `GlobalPalStorage.sav` workflow.

- Loads local player Palboxes, party/travel Pals, and working/base Pals from `Level.sav` with matching `Players/*.sav` context.
- Clones/imports Pals by updating the character map, target container slot, and guild handle together.
- Deletes Pals only when character, container, and guild references are structurally consistent.
- Fails closed for missing/stale player saves, full or malformed containers, player-shaped sources, duplicate IDs, and duplicate guild references.
- Caps compressed save input and decompressed GVAS output at 512 MiB for world and player saves.
- Writes through an exclusive same-directory temporary file, verifies the loaded target immediately before replacement, and installs with an atomic filesystem replace. A narrow race with an uncooperative external writer remains a documented platform limitation.

## Save-integrity behavior

- Capacity is bounded by `SlotNum`, with unique in-range slot indexes.
- Batch imports preflight the entire operation and roll back if any insertion fails.
- Unknown and untouched save properties remain preserved.
- Existing backups remain part of the normal save flow.
- Serialization is verified by compressing, decompressing, byte-comparing, fully reparsing, and serializing the reparsed GVAS again before disk replacement.

## Verification

- `python -m unittest discover -v` — 51 tests passed.
- `python -m compileall -q PalEdit.py palworld_pal_edit palworld_save_tools tests` — passed.
- `git diff --check` — passed.
- Source GUI startup smoke test — passed.
- Static added-line security scan — no secrets, shell execution, `eval`/`exec`, unsafe pickle, or SQL construction found.
- Public `v1_relics/Level.sav` fixture:
  - no-op output was byte-identical;
  - clone output reparsed with matching character/container/guild references;
  - deleting the clone restored the original raw GVAS bytes exactly.

## Packaging note

The repository's pre-existing PyInstaller one-file build still does not bundle the native `ooz` module. Source execution and save verification work; this PR does not claim to fix that separate packaging issue.
